### PR TITLE
Add mcp-tada/cli subpath export for programmatic introspect and check

### DIFF
--- a/.changeset/cli-subpath-export.md
+++ b/.changeset/cli-subpath-export.md
@@ -1,0 +1,5 @@
+---
+"mcp-tada": minor
+---
+
+Add a `mcp-tada/cli` entry exporting `introspect`, `check`, and their building blocks for programmatic use, replacing the unreachable `dist/cli/*` deep imports.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,6 +191,37 @@ mcp-tada check
 
 ## Programmatic use
 
-`introspect()` and `check()` are also exported from `mcp-tada/dist/cli/introspect.js` and
-`mcp-tada/dist/cli/check.js` for tooling that wants to call them directly instead of shelling
-out, e.g. from a build script or test suite.
+The same code the CLI runs is exported from the `mcp-tada/cli` subpath, minus argv parsing, so a
+build script or test suite can drive it directly instead of shelling out. It is a separate entry
+from `mcp-tada` because it imports `node:fs` and the SDK transports, which the zero-runtime
+client entry must stay free of.
+
+```ts
+import { check, introspect } from "mcp-tada/cli";
+
+const target = { command: "node", args: ["server.js"], timeoutMs: 5000 };
+
+// Same as `mcp-tada introspect --command "node server.js" --out src/introspection.d.ts`.
+const { data, wrote } = await introspect({ target, out: "src/introspection.d.ts" });
+
+// Same as `mcp-tada check ... --against src/introspection.d.ts`; exit code is up to you.
+const { report, text } = await check({ target, against: "src/introspection.d.ts" });
+if (!report.identical) throw new Error(text);
+```
+
+`introspect(options)` connects, pages `tools/list`, and by default writes the snapshot
+(`write: false` skips the file and only returns `text` and `data`). It takes the same `out`,
+`name`, `json`, and `verbose` options as the flags. `check(options)` re-introspects and returns
+`{ report, text }`, where `report` has `added`, `removed`, `inputChanged`, `outputAppeared`,
+`outputDisappeared`, `outputChanged`, and `identical`.
+
+A `ServerTarget` is `{ command?, args?, env?, url?, headers?, timeoutMs? }`, the normalized form of
+the target flags. Unlike the CLI, no default timeout is applied unless you set `timeoutMs`
+(`DEFAULT_TIMEOUT_MS` is exported). `loadConfig(path)` reads an `mcp-tada.config.json` or an
+`mcpServers` file into `{ servers }`, each entry a `ServerTarget` plus `output`.
+
+The building blocks are exported too, for tooling that wants to compose its own flow:
+`connectClient` and `introspectTarget` (connect and list without writing anything),
+`buildIntrospectionData`, `collectWarnings`, `formatDts`, `formatJson`, and `writeIfChanged` on
+the introspect side; `diffIntrospection` and `formatReport` on the check side; and
+`parseSnapshotText`, `parseDtsSnapshot`, and `detectFormat` for reading a snapshot back.

--- a/packages/mcp-tada/README.md
+++ b/packages/mcp-tada/README.md
@@ -86,6 +86,21 @@ Aliases are validated at construction. The separator defaults to `__` and is con
 
 Draft-07 and 2020-12: `type` including arrays of types, `properties` with `required` and `additionalProperties`, `items` and `prefixItems`, `enum`, `const`, `anyOf`, `oneOf`, `allOf`, `nullable`, `$ref` into `$defs` or `definitions`, and `properties` without an explicit `type`. Unsupported keywords degrade to `unknown` rather than failing.
 
+## From a build script
+
+Everything the CLI does is also exported from `mcp-tada/cli`, so you can generate or check a snapshot without shelling out:
+
+```ts
+import { check, introspect } from "mcp-tada/cli";
+
+const target = { url: "https://mcp.deepwiki.com/mcp", timeoutMs: 10_000 };
+await introspect({ target, out: "src/deepwiki.introspection.d.ts" });
+const { report, text } = await check({ target, against: "src/deepwiki.introspection.d.ts" });
+if (!report.identical) throw new Error(text);
+```
+
+The main `mcp-tada` entry stays free of `node:fs` and transport imports; see the repository docs for the full `mcp-tada/cli` surface.
+
 ## Server side
 
 If you also write the server, [`mcp-tada-server`](https://www.npmjs.com/package/mcp-tada-server) declares tools once and gives the client the same types with no introspection step.

--- a/packages/mcp-tada/package.json
+++ b/packages/mcp-tada/package.json
@@ -11,6 +11,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./cli": {
+      "types": "./dist/cli/index.d.ts",
+      "import": "./dist/cli/index.js"
     }
   },
   "files": [

--- a/packages/mcp-tada/src/cli/index.ts
+++ b/packages/mcp-tada/src/cli/index.ts
@@ -1,0 +1,45 @@
+// Programmatic surface of the CLI, published as `mcp-tada/cli`. Everything here is what
+// `mcp-tada introspect` and `mcp-tada check` run, minus argv parsing, so a build script or test
+// suite can drive the same code without shelling out. Kept off the main `mcp-tada` entry so that
+// one stays free of `node:fs` and transport imports.
+export {
+  DEFAULT_TIMEOUT_MS,
+  connectClient,
+  describeTarget,
+  loadConfig,
+  type ConnectOptions,
+  type ConnectedClient,
+  type McpTadaConfig,
+  type ServerConfigEntry,
+  type ServerTarget,
+} from "./connect.js";
+export {
+  buildIntrospectionData,
+  collectWarnings,
+  formatDts,
+  formatJson,
+  introspect,
+  introspectTarget,
+  writeIfChanged,
+  type FormatDtsOptions,
+  type IntrospectMeta,
+  type IntrospectOptions,
+  type IntrospectRunResult,
+  type IntrospectWarnings,
+} from "./introspect.js";
+export {
+  check,
+  diffIntrospection,
+  formatReport,
+  type CheckOptions,
+  type CheckReport,
+  type CheckRunResult,
+} from "./check.js";
+export {
+  detectFormat,
+  parseDtsSnapshot,
+  parseSnapshotText,
+  type IntrospectionData,
+  type SnapshotFormat,
+  type ToolSnapshot,
+} from "./snapshot.js";

--- a/packages/mcp-tada/test/cli-entry.test.ts
+++ b/packages/mcp-tada/test/cli-entry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { createRequire } from "node:module";
+import * as cli from "../src/cli/index.js";
+
+describe("mcp-tada/cli entry", () => {
+  it("exposes the introspect and check surface", () => {
+    expect(typeof cli.introspect).toBe("function");
+    expect(typeof cli.introspectTarget).toBe("function");
+    expect(typeof cli.check).toBe("function");
+    expect(typeof cli.diffIntrospection).toBe("function");
+    expect(typeof cli.formatReport).toBe("function");
+    expect(typeof cli.connectClient).toBe("function");
+    expect(typeof cli.loadConfig).toBe("function");
+    expect(typeof cli.formatDts).toBe("function");
+    expect(typeof cli.formatJson).toBe("function");
+    expect(typeof cli.parseSnapshotText).toBe("function");
+    expect(typeof cli.detectFormat).toBe("function");
+    expect(cli.DEFAULT_TIMEOUT_MS).toBe(30_000);
+  });
+
+  it("is published as the ./cli subpath of the package", () => {
+    const require = createRequire(import.meta.url);
+    const pkg = require("../package.json") as {
+      exports: Record<string, { types: string; import: string }>;
+    };
+    expect(pkg.exports["./cli"]).toEqual({
+      types: "./dist/cli/index.d.ts",
+      import: "./dist/cli/index.js",
+    });
+  });
+
+  it("does not pull the CLI's argv handling into the entry", () => {
+    expect("runIntrospectWith" in cli).toBe(false);
+    expect("runCheckWith" in cli).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `docs/cli.md` told programmatic users to import `introspect()` and `check()` from `mcp-tada/dist/cli/introspect.js` and `mcp-tada/dist/cli/check.js`, but the package's `exports` map only exposes `.`, so those imports fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
- Adds a `src/cli/index.ts` barrel published as the `mcp-tada/cli` subpath. It exports `introspect`, `introspectTarget`, `check`, `diffIntrospection`, `formatReport`, `connectClient`, `loadConfig`, `formatDts`, `formatJson`, `buildIntrospectionData`, `collectWarnings`, `writeIfChanged`, the snapshot parsers, `DEFAULT_TIMEOUT_MS`, and their types.
- The argv handling in `main.ts` stays out of the entry, and the main `mcp-tada` entry stays free of `node:fs` and transport imports, so the zero-runtime promise is untouched.
- Documents the surface in `docs/cli.md` and adds a short "From a build script" section to the package README.
- No related issue.
