### PR TITLE
Skip staging a version whose release tag already exists

### DIFF
--- a/.github/scripts/has-unpublished-packages.mjs
+++ b/.github/scripts/has-unpublished-packages.mjs
@@ -1,6 +1,7 @@
 import { appendFileSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
+import { hasRemoteReleaseTag, releaseTagName } from "./release-tags.mjs";
 
 const ignoredDirectories = new Set([".git", "dist", "node_modules"]);
 
@@ -51,10 +52,12 @@ async function main() {
   let hasUnpublished = false;
 
   for (const pkg of packages) {
-    const isPublished = await hasPublishedVersion(pkg);
-
-    if (isPublished) {
+    if (await hasPublishedVersion(pkg)) {
       console.log(`${pkg.name}@${pkg.version} is already published`);
+    } else if (await hasRemoteReleaseTag(pkg.name, pkg.version)) {
+      console.log(
+        `${pkg.name}@${pkg.version} is staged and awaiting \`npm stage approve\` (tag ${releaseTagName(pkg.name, pkg.version)} exists)`,
+      );
     } else {
       console.log(`${pkg.name}@${pkg.version} is not published yet`);
       hasUnpublished = true;

--- a/.github/scripts/release-tags.mjs
+++ b/.github/scripts/release-tags.mjs
@@ -1,0 +1,52 @@
+// Shared by has-unpublished-packages.mjs and stage-packages.mjs.
+//
+// Publishing is two-phase: `pnpm stage publish` uploads a version that stays invisible on the
+// registry until someone runs `npm stage approve`. In that window the registry still reports the
+// version as unpublished, so a naive check would stage it again on the next push to main and then
+// fail on the `name@version` git tag and GitHub release the first run already created. The tag is
+// therefore the marker for "staged, awaiting approval": if it exists on the remote, leave the
+// version alone.
+import { spawnSync } from "node:child_process";
+
+export function releaseTagName(name, version) {
+  return `${name}@${version}`;
+}
+
+/** True when `refs/tags/<name>@<version>` exists on the GitHub remote. Uses the REST API with
+ * `GITHUB_TOKEN` when both it and `GITHUB_REPOSITORY` are set (the checkout does not persist
+ * credentials), and falls back to `git ls-remote` otherwise. */
+export async function hasRemoteReleaseTag(name, version) {
+  const tag = releaseTagName(name, version);
+  const repo = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN;
+
+  if (repo && token) {
+    const response = await fetch(
+      `https://api.github.com/repos/${repo}/git/ref/tags/${encodeURIComponent(tag)}`,
+      {
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${token}`,
+          "x-github-api-version": "2022-11-28",
+        },
+      },
+    );
+    if (response.status === 404) return false;
+    if (!response.ok) {
+      throw new Error(`Failed to look up tag ${tag}: ${response.status} ${response.statusText}`);
+    }
+    return true;
+  }
+
+  const result = spawnSync(
+    "git",
+    ["ls-remote", "--exit-code", "--tags", "origin", `refs/tags/${tag}`],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  if (result.status === 0) return true;
+  if (result.status === 2) return false;
+  throw new Error(`Failed to look up tag ${tag} via git ls-remote: ${result.stderr}`);
+}

--- a/.github/scripts/release-tags.mjs
+++ b/.github/scripts/release-tags.mjs
@@ -5,7 +5,8 @@
 // version as unpublished, so a naive check would stage it again on the next push to main and then
 // fail on the `name@version` git tag and GitHub release the first run already created. The tag is
 // therefore the marker for "staged, awaiting approval": if it exists on the remote, leave the
-// version alone.
+// version alone. If a stage is abandoned instead of approved, delete that tag (and its GitHub
+// release) to let the next push to main stage the version again.
 import { spawnSync } from "node:child_process";
 
 export function releaseTagName(name, version) {
@@ -22,7 +23,9 @@ export async function hasRemoteReleaseTag(name, version) {
 
   if (repo && token) {
     const response = await fetch(
-      `https://api.github.com/repos/${repo}/git/ref/tags/${encodeURIComponent(tag)}`,
+      // Encode each path segment separately: a scoped package tag (`@scope/name@1.0.0`) keeps
+      // its `/`, which the ref endpoint expects literally.
+      `https://api.github.com/repos/${repo}/git/ref/tags/${tag.split("/").map(encodeURIComponent).join("/")}`,
       {
         headers: {
           accept: "application/vnd.github+json",

--- a/.github/scripts/stage-packages.mjs
+++ b/.github/scripts/stage-packages.mjs
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
+import { hasRemoteReleaseTag, releaseTagName } from "./release-tags.mjs";
 
 const root = process.cwd();
 const config = JSON.parse(readFileSync(join(root, ".changeset/config.json"), "utf8"));
@@ -106,6 +107,12 @@ for (const packageJsonPath of packageJsonPaths()) {
   if (!pkg.name || !pkg.version || pkg.private || ignored.has(pkg.name)) continue;
   if (versionExists(pkg.name, pkg.version)) {
     console.log(`Skipping ${pkg.name}@${pkg.version}; already published.`);
+    continue;
+  }
+  if (await hasRemoteReleaseTag(pkg.name, pkg.version)) {
+    console.log(
+      `Skipping ${pkg.name}@${pkg.version}; already staged and awaiting \`npm stage approve\` (tag ${releaseTagName(pkg.name, pkg.version)} exists).`,
+    );
     continue;
   }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # A version that is staged but not yet approved with `npm stage approve` is still absent
+      # from the registry; its `<name>@<version>` tag (pushed by the publish job) marks it as
+      # done so a later push to main does not stage it a second time.
       - name: Check for unpublished package versions
         if: steps.changesets.outputs.hasChangesets == 'false'
         id: publish-check
         run: node .github/scripts/has-unpublished-packages.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
     name: Publish


### PR DESCRIPTION
## Summary

- Root cause of the failing Release runs: publishing is two-phase. `pnpm stage publish` uploads a version that stays absent from the registry until `npm stage approve`. In run 34512315328 the check ran at 18:10:05 and the 0.1.0 approval landed on npm at 18:10:57, so the check saw `mcp-tada@0.1.0 is not published yet`, the publish job staged it a second time, and then failed with `Reference already exists` on the tag and `already_exists` on the GitHub release the first run had created.
- `has-unpublished-packages.mjs` and `stage-packages.mjs` now share `release-tags.mjs`, which checks whether `refs/tags/<name>@<version>` exists on the remote (GitHub REST with `GITHUB_TOKEN`, falling back to `git ls-remote`). An existing tag means "staged, awaiting approval": the check reports it as done and the publish job is not reached. This also covers registry metadata lagging behind an approval.
- The check step in `release.yml` now receives `GITHUB_TOKEN` for the lookup.

Verified locally: the check reports both current versions as published; the tag lookup returns true for `mcp-tada@0.1.0` and `mcp-tada-server@0.0.2` and false for a made-up version, on both the API and `ls-remote` paths.

## Testing

- [x] `pnpm run verify` (format, lint, build, typecheck, test)

## Checklist

- [x] Docs updated if needed (N/A, comments in the workflow and script)
- [x] Concise, user-facing changeset added if the published package changed (N/A, release tooling only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEnRP4bKXY2jSg5RrbxyKY
