### PR TITLE
Add mcp-tada/testing with a typed in-memory mock client

### DIFF
--- a/.changeset/testing-entry.md
+++ b/.changeset/testing-entry.md
@@ -1,0 +1,5 @@
+---
+"mcp-tada": minor
+---
+
+Add `mockMcpTada` under `mcp-tada/testing`, a typed in-memory `TypedClient` whose handlers are checked against the snapshot and which records every call for assertions.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,26 @@ combined.servers.gh; // direct access to the underlying typed client
 combined.split("gh__search"); // -> { server: "gh", tool: "search" }
 ```
 
+## Testing
+
+`mcp-tada/testing` exports `mockMcpTada<introspection>(handlers)`, a `TypedClient` backed by in-memory handlers instead of a server. Each handler's arguments are typed from the tool's `inputSchema`, and its return is either a full result or, for a tool with an `outputSchema`, the bare `structuredContent`, which the mock wraps the way an SDK server would. Both maps are partial: calling an unmocked tool throws, naming it, so a test only describes what it exercises. Every call is recorded on `calls` (and `promptCalls`), as a union on `name` so a comparison narrows `args`.
+
+```ts
+import { mockMcpTada } from "mcp-tada/testing";
+
+const mcp = mockMcpTada<introspection>({
+  tools: {
+    read_file: ({ path }) => ({ content: [{ type: "text", text: `contents of ${path}` }] }),
+    get_weather: ({ city }) => ({ temperature: 20, conditions: `sunny in ${city}` }),
+  },
+});
+
+await runAgent(mcp); // anything that takes a TypedClient<introspection>
+expect(mcp.calls).toEqual([{ name: "read_file", args: { path: "README.md" } }]);
+```
+
+The mock is a real `TypedClient`, so `readOnly` and `combineMcpTada` accept it. Its `client` property throws on any access, since there is no SDK client behind it. `listTools()` reports the mocked names only; schemas live in the snapshot type.
+
 ## Workflow
 
 The snapshot is a committed file, and the commands map onto the moments where it can go stale.

--- a/packages/mcp-tada/package.json
+++ b/packages/mcp-tada/package.json
@@ -15,6 +15,10 @@
     "./cli": {
       "types": "./dist/cli/index.d.ts",
       "import": "./dist/cli/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "import": "./dist/testing.js"
     }
   },
   "files": [

--- a/packages/mcp-tada/skills/mcp-tada-integration/SKILL.md
+++ b/packages/mcp-tada/skills/mcp-tada-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-tada-integration
-description: Wire mcp-tada into a project so MCP tool calls are typed at compile time - config, snapshot, typed client, read-only views, multi-server clients, and the CI steps that keep the snapshot honest. Use when writing or reviewing code that calls an MCP server through mcp-tada.
+description: Wire mcp-tada into a project so MCP tool calls are typed at compile time - config, snapshot, typed client, read-only views, multi-server clients, the in-memory mock client for tests, and the CI steps that keep the snapshot honest. Use when writing or reviewing code that calls an MCP server through mcp-tada.
 ---
 
 # Using mcp-tada in a project
@@ -56,6 +56,36 @@ if (!result.isError) result.structuredContent; // typed from outputSchema, else 
   `servers.<alias>.getPrompt(...)`.
 - For a code-mode agent, give the model the snapshot text as the API declaration and let its
   program call `mcp.tools.*` in a sandbox. `node:vm` isolates scope, not privileges.
+
+## Testing
+
+`mcp-tada/testing` exports `mockMcpTada<introspection>({ tools, prompts })`, a `TypedClient`
+backed by in-memory handlers instead of a server, so code that takes a typed client can be
+tested without spawning one.
+
+```ts
+import { mockMcpTada } from "mcp-tada/testing";
+
+const mcp = mockMcpTada<introspection>({
+  tools: {
+    read_file: ({ path }) => ({ content: [{ type: "text", text: `contents of ${path}` }] }),
+    get_weather: ({ city }) => ({ temperature: 20, conditions: `sunny in ${city}` }),
+  },
+});
+
+await runAgent(mcp);
+expect(mcp.calls).toEqual([{ name: "read_file", args: { path: "README.md" } }]);
+```
+
+- Handler arguments are typed from the tool's `inputSchema`. A tool with an `outputSchema` may
+  return the bare `structuredContent`; the mock wraps it the way an SDK server would. A tool
+  without one must return a full result.
+- Both maps are partial. An unmocked tool or prompt throws, naming it, so a test only describes
+  what it exercises.
+- `calls` and `promptCalls` are unions on `name`, so `call.name === "x"` narrows `args`.
+  `reset()` clears them.
+- It is a real `TypedClient`, so `readOnly` and `combineMcpTada` accept it. `client` throws on
+  access, since there is no SDK client behind it, and `listTools()` reports the mocked names only.
 
 ## CI
 

--- a/packages/mcp-tada/src/testing.ts
+++ b/packages/mcp-tada/src/testing.ts
@@ -1,0 +1,190 @@
+// `mcp-tada/testing`: a typed fake for code that consumes a `TypedClient`. Handlers are checked
+// against the same snapshot as the real client, so a test that hands the wrong shape to an agent
+// fails to compile instead of failing at runtime. Nothing here talks to a server or the SDK.
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type {
+  CallToolResult,
+  GetPromptResult,
+  Prompt,
+  Tool,
+} from "@modelcontextprotocol/sdk/types.js";
+import type {
+  Introspection,
+  ToolArgs,
+  ToolMethods,
+  ToolNames,
+  ToolOutput,
+  TypedClient,
+} from "./index.js";
+import type { PromptArgs, PromptNames } from "./prompts.js";
+
+/**
+ * What a mocked tool may resolve to: a full `CallToolResult` (typed like the real client's
+ * result, so `isError: true` is allowed), or, for a tool with an `outputSchema`, the bare
+ * `structuredContent`, which the mock wraps the way an SDK server would (serialized into a
+ * single text block plus `structuredContent`). A bare value that itself has a `content` array
+ * is read as a full result; wrap it explicitly in that case.
+ */
+export type MockToolReturn<I extends Introspection, N extends ToolNames<I>> =
+  | { content: CallToolResult["content"]; isError: true; structuredContent?: unknown }
+  | (I["tools"][N] extends { outputSchema: unknown }
+      ?
+          | ToolOutput<I, N>
+          | {
+              content: CallToolResult["content"];
+              isError?: false;
+              structuredContent: ToolOutput<I, N>;
+            }
+      : { content: CallToolResult["content"]; isError?: false; structuredContent?: unknown });
+
+/** A mocked tool: a fixed value, or a function of the typed `args` (and the call's options). */
+export type MockToolHandler<I extends Introspection, N extends ToolNames<I>> =
+  | MockToolReturn<I, N>
+  | ((
+      args: ToolArgs<I, N>,
+      options?: RequestOptions,
+    ) => MockToolReturn<I, N> | Promise<MockToolReturn<I, N>>);
+
+export type MockPromptHandler<I extends Introspection, N extends PromptNames<I>> =
+  | GetPromptResult
+  | ((
+      args: PromptArgs<I, N>,
+      options?: RequestOptions,
+    ) => GetPromptResult | Promise<GetPromptResult>);
+
+/** Everything a mock can answer. Both maps are partial: an unmocked tool or prompt throws when
+ * called, naming the tool, so a test only describes what it exercises. */
+export type MockHandlers<I extends Introspection> = {
+  tools?: { [N in ToolNames<I>]?: MockToolHandler<I, N> };
+  prompts?: { [N in PromptNames<I>]?: MockPromptHandler<I, N> };
+};
+
+/** One recorded `callTool`, as a union over tool names so `call.name === "x"` narrows `args`. */
+export type MockCall<I extends Introspection> = {
+  [N in ToolNames<I>]: { name: N; args: ToolArgs<I, N> | undefined; options?: RequestOptions };
+}[ToolNames<I>];
+
+export type MockPromptCall<I extends Introspection> = {
+  [N in PromptNames<I>]: { name: N; args: PromptArgs<I, N> | undefined; options?: RequestOptions };
+}[PromptNames<I>];
+
+export type MockClient<I extends Introspection> = TypedClient<I> & {
+  /** Every `callTool` / `tools.<name>()` made so far, oldest first. */
+  calls: MockCall<I>[];
+  /** Every `getPrompt` made so far, oldest first. */
+  promptCalls: MockPromptCall<I>[];
+  /** Forget recorded calls. Handlers are kept. */
+  reset(): void;
+};
+
+const reserved = new Set(["then", "catch", "finally", "toJSON", "constructor", "prototype"]);
+
+function toolMethods<T>(
+  call: (name: string, args?: unknown, options?: RequestOptions) => Promise<unknown>,
+): T {
+  const cache = new Map<string, (args?: unknown, options?: RequestOptions) => Promise<unknown>>();
+  return new Proxy(Object.create(null) as object, {
+    get(_target, prop) {
+      if (typeof prop !== "string" || reserved.has(prop)) return undefined;
+      let method = cache.get(prop);
+      if (!method) {
+        method = (args, options) => call(prop, args, options);
+        cache.set(prop, method);
+      }
+      return method;
+    },
+  }) as T;
+}
+
+/** Stands in for `client` on the mock: any property read explains that there is no SDK client
+ * behind it, instead of a bare "cannot read properties of undefined" deep in the code under test.
+ * Symbols and `then` read as `undefined` so inspectors and `await` do not trip over it. */
+function noClient(): Client {
+  return new Proxy(Object.create(null) as object, {
+    get(_target, prop) {
+      if (typeof prop !== "string" || prop === "then") return undefined;
+      throw new Error(
+        `mcp-tada/testing: this mock has no underlying SDK Client (tried to read client.${prop})`,
+      );
+    },
+  }) as Client;
+}
+
+function isFullResult(value: unknown): value is { content: unknown[] } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Array.isArray((value as { content?: unknown }).content)
+  );
+}
+
+/**
+ * Builds a `TypedClient<I>` backed by in-memory handlers instead of a server. It has the same
+ * `callTool`, `tools`, `getPrompt`, `listTools`, and `listPrompts` as the real client, plus a
+ * `calls` log for assertions. `listTools()` and `listPrompts()` report the mocked names only;
+ * schemas live in the snapshot type, not in the mock.
+ *
+ * ```ts
+ * const mcp = mockMcpTada<introspection>({
+ *   tools: {
+ *     "get-structured-content": ({ location }) => ({ temperature: 20, conditions: "sunny" }),
+ *     "get-sum": { content: [{ type: "text", text: "5" }] },
+ *   },
+ * });
+ * await runAgent(mcp);
+ * expect(mcp.calls[0]).toEqual({ name: "get-sum", args: { a: 2, b: 3 } });
+ * ```
+ */
+export function mockMcpTada<I extends Introspection>(
+  handlers: MockHandlers<I> = {},
+): MockClient<I> {
+  const tools = (handlers.tools ?? {}) as Record<string, unknown>;
+  const prompts = (handlers.prompts ?? {}) as Record<string, unknown>;
+  const calls: MockCall<I>[] = [];
+  const promptCalls: MockPromptCall<I>[] = [];
+
+  async function callTool(name: string, args?: unknown, options?: RequestOptions) {
+    const record = { name, args } as MockCall<I>;
+    if (options !== undefined) record.options = options;
+    calls.push(record);
+    if (!(name in tools)) {
+      throw new Error(`mcp-tada/testing: no mock handler for tool "${name}"`);
+    }
+    const handler = tools[name];
+    const value = typeof handler === "function" ? await handler(args, options) : handler;
+    if (isFullResult(value)) return value;
+    return {
+      content: [{ type: "text", text: JSON.stringify(value) }],
+      structuredContent: value,
+    };
+  }
+
+  async function getPrompt(name: string, args?: unknown, options?: RequestOptions) {
+    const record = { name, args } as MockPromptCall<I>;
+    if (options !== undefined) record.options = options;
+    promptCalls.push(record);
+    if (!(name in prompts)) {
+      throw new Error(`mcp-tada/testing: no mock handler for prompt "${name}"`);
+    }
+    const handler = prompts[name];
+    return typeof handler === "function" ? await handler(args, options) : handler;
+  }
+
+  const mock = {
+    client: noClient(),
+    callTool,
+    getPrompt,
+    tools: toolMethods<ToolMethods<I>>(callTool),
+    listTools: async (): Promise<Tool[]> =>
+      Object.keys(tools).map((name) => ({ name, inputSchema: { type: "object" } })),
+    listPrompts: async (): Promise<Prompt[]> => Object.keys(prompts).map((name) => ({ name })),
+    calls,
+    promptCalls,
+    reset() {
+      calls.length = 0;
+      promptCalls.length = 0;
+    },
+  };
+  return mock as unknown as MockClient<I>;
+}

--- a/packages/mcp-tada/test/testing.test-d.ts
+++ b/packages/mcp-tada/test/testing.test-d.ts
@@ -1,0 +1,54 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type { TypedClient } from "../src/index.js";
+import { mockMcpTada } from "../src/testing.js";
+import type { introspection } from "./fixtures/everything.introspection.d.ts";
+
+describe("mockMcpTada types", () => {
+  it("is a TypedClient of the same introspection", () => {
+    const mcp = mockMcpTada<introspection>();
+    expectTypeOf(mcp).toMatchTypeOf<TypedClient<introspection>>();
+  });
+
+  it("types handler args from inputSchema", () => {
+    mockMcpTada<introspection>({
+      tools: {
+        "get-sum": ({ a, b }) => {
+          expectTypeOf(a).toEqualTypeOf<number>();
+          expectTypeOf(b).toEqualTypeOf<number>();
+          return { content: [] };
+        },
+      },
+    });
+  });
+
+  it("accepts a bare structuredContent only for tools with an outputSchema", () => {
+    mockMcpTada<introspection>({
+      tools: {
+        "get-structured-content": () => ({ temperature: 1, conditions: "x", humidity: 2 }),
+        // @ts-expect-error get-sum has no outputSchema, so only a full result is accepted
+        "get-sum": () => ({ sum: 3 }),
+      },
+    });
+    mockMcpTada<introspection>({
+      tools: {
+        // @ts-expect-error conditions must be a string
+        "get-structured-content": () => ({ temperature: 1, conditions: 2, humidity: 2 }),
+      },
+    });
+  });
+
+  it("rejects unknown tool names", () => {
+    mockMcpTada<introspection>({
+      // @ts-expect-error not a tool in the snapshot
+      tools: { nope: { content: [] } },
+    });
+  });
+
+  it("narrows recorded calls on name", () => {
+    const mcp = mockMcpTada<introspection>();
+    const call = mcp.calls[0];
+    if (call?.name === "get-sum") {
+      expectTypeOf(call.args).toEqualTypeOf<{ a: number; b: number } | undefined>();
+    }
+  });
+});

--- a/packages/mcp-tada/test/testing.test.ts
+++ b/packages/mcp-tada/test/testing.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { combineMcpTada, readOnly } from "../src/index.js";
+import { mockMcpTada } from "../src/testing.js";
+import type { introspection } from "./fixtures/everything.introspection.d.ts";
+
+describe("mockMcpTada", () => {
+  it("wraps a bare structuredContent the way a server would", async () => {
+    const mcp = mockMcpTada<introspection>({
+      tools: {
+        "get-structured-content": ({ location }) => ({
+          temperature: 20,
+          conditions: `sunny in ${location}`,
+          humidity: 40,
+        }),
+      },
+    });
+    const result = await mcp.callTool("get-structured-content", { location: "Chicago" });
+    expect(result.isError).toBeUndefined();
+    if (result.isError) throw new Error("unexpected");
+    expect(result.structuredContent.conditions).toBe("sunny in Chicago");
+    expect(result.content).toEqual([
+      { type: "text", text: JSON.stringify(result.structuredContent) },
+    ]);
+  });
+
+  it("passes a full result through untouched, including errors", async () => {
+    const mcp = mockMcpTada<introspection>({
+      tools: {
+        "get-sum": { content: [{ type: "text", text: "boom" }], isError: true },
+      },
+    });
+    const result = await mcp.tools["get-sum"]({ a: 1, b: 2 });
+    expect(result).toEqual({ content: [{ type: "text", text: "boom" }], isError: true });
+  });
+
+  it("records calls with their args, and throws for an unmocked tool", async () => {
+    const mcp = mockMcpTada<introspection>({
+      tools: { echo: ({ message }) => ({ content: [{ type: "text", text: message }] }) },
+    });
+    await mcp.callTool("echo", { message: "hi" });
+    await mcp.tools.echo({ message: "again" });
+    expect(mcp.calls).toEqual([
+      { name: "echo", args: { message: "hi" } },
+      { name: "echo", args: { message: "again" } },
+    ]);
+    await expect(mcp.callTool("get-sum", { a: 1, b: 2 })).rejects.toThrow(
+      'no mock handler for tool "get-sum"',
+    );
+    mcp.reset();
+    expect(mcp.calls).toEqual([]);
+  });
+
+  it("lists only the mocked tools and prompts", async () => {
+    const mcp = mockMcpTada<introspection>({
+      tools: { echo: { content: [] } },
+      prompts: {
+        "args-prompt": ({ city }) => ({
+          messages: [{ role: "user", content: { type: "text", text: `Weather in ${city}?` } }],
+        }),
+      },
+    });
+    expect((await mcp.listTools()).map((t) => t.name)).toEqual(["echo"]);
+    expect((await mcp.listPrompts()).map((p) => p.name)).toEqual(["args-prompt"]);
+    const prompt = await mcp.getPrompt("args-prompt", { city: "Chicago" });
+    expect(JSON.stringify(prompt.messages)).toContain("Chicago");
+    expect(mcp.promptCalls).toEqual([{ name: "args-prompt", args: { city: "Chicago" } }]);
+  });
+
+  it("explains itself when the code under test reaches for the SDK client", () => {
+    const mcp = mockMcpTada<introspection>();
+    expect(() => mcp.client.listTools()).toThrow("no underlying SDK Client");
+  });
+
+  it("works with readOnly and combineMcpTada like a real client", async () => {
+    const mcp = mockMcpTada<introspection>({
+      tools: { "get-sum": { content: [{ type: "text", text: "3" }] } },
+    });
+    const ro = readOnly(mcp);
+    expect((await ro.listTools()).map((t) => t.name)).toEqual([]);
+    const combined = combineMcpTada({ every: mcp });
+    const result = await combined.callTool("every__get-sum", { a: 1, b: 2 });
+    expect(JSON.stringify(result.content)).toContain("3");
+    expect(mcp.calls).toEqual([{ name: "get-sum", args: { a: 1, b: 2 } }]);
+  });
+});


### PR DESCRIPTION
## Summary

- New `mcp-tada/testing` subpath exporting `mockMcpTada<introspection>({ tools, prompts })`, a `TypedClient` backed by in-memory handlers instead of a server.
- Handler arguments are typed from `inputSchema`. A tool with an `outputSchema` may return the bare `structuredContent`, which the mock wraps the way an SDK server would (one text block plus `structuredContent`); tools without one must return a full result, enforced at the type level.
- Both handler maps are partial; an unmocked tool or prompt throws with its name. Calls land on `calls` and `promptCalls` as a union on `name`, so `call.name === "x"` narrows `args`. `reset()` clears them.
- The mock is a real `TypedClient`, so `readOnly` and `combineMcpTada` accept it; `client` throws a clear message on access.
- Covered by runtime tests and a `.test-d.ts` with `@ts-expect-error` cases.

## Testing

- [x] `pnpm run verify` (format, lint, build, typecheck, test)

## Checklist

- [x] Docs updated if needed
- [x] Concise, user-facing changeset added if the published package changed