### PR TITLE
Add mcp-tada init and mcp-tada doctor

### DIFF
--- a/.changeset/init-and-doctor.md
+++ b/.changeset/init-and-doctor.md
@@ -1,0 +1,5 @@
+---
+"mcp-tada": minor
+---
+
+Add `mcp-tada init`, which writes `mcp-tada.config.json` from a project's `.mcp.json`, Cursor, VS Code, or Claude Desktop server list, and `mcp-tada doctor`, which checks installed versions, the config, every snapshot, and whether each server answers.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ Off-the-shelf type-level mappers were measured at over 12 million type instantia
 
 ## CLI
 
+### `mcp-tada init`
+
+Writes `mcp-tada.config.json` from the servers your project already configures for its editor or agent, so the first `introspect` needs no flags. It reads the first of `.mcp.json`, `.cursor/mcp.json`, `.vscode/mcp.json`, or the Claude Desktop config, or the file given with `--from`, and gives every server an `output` under `src/` (or `--out-dir`). Values in `env` and `headers` are copied verbatim, and `init` warns about any that look like secrets. `--force` overwrites an existing config.
+
+```sh
+mcp-tada init
+mcp-tada init --from ~/Library/Application\ Support/Claude/claude_desktop_config.json --out-dir src/mcp
+```
+
+### `mcp-tada doctor`
+
+Runs the setup checks people otherwise discover one failed command at a time: the installed `@modelcontextprotocol/sdk` and `typescript` versions, that the config loads and no two servers share an `output`, that each snapshot exists and parses back, and, unless `--offline`, that each server answers and still matches its snapshot. Exits 1 on any failure. Warnings alone exit 0.
+
+```sh
+mcp-tada doctor
+mcp-tada doctor --offline --config mcp-tada.config.json
+```
+
 ### `mcp-tada introspect`
 
 ```sh

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,8 +2,9 @@
 
 A zero-runtime typed client for Model Context Protocol tool
 calls, derived from a generated `introspection.d.ts` snapshot of a server's `tools/list`. This
-document covers the CLI: `introspect` (generate the snapshot) and `check` (diff a live server
-against a snapshot), plus `--help` and `--version`.
+document covers the CLI: `init` (write a config from an existing server list), `doctor` (check
+the setup), `introspect` (generate the snapshot) and `check` (diff a live server against a
+snapshot), plus `--help` and `--version`.
 
 ## Install
 
@@ -12,6 +13,58 @@ npm install -D mcp-tada
 ```
 
 The `mcp-tada` binary is installed by the package (`bin/mcp-tada.js`).
+
+## `mcp-tada init`
+
+```
+mcp-tada init [--from <path>] [--out-dir <dir>] [--config <path>] [--force]
+```
+
+Writes an `mcp-tada.config.json` from an MCP server list the project already has. Without
+`--from`, the first of these that exists is used, in this order: `.mcp.json` (Claude Code),
+`.cursor/mcp.json`, `.vscode/mcp.json` (a `servers` block), then the user's Claude Desktop
+config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS,
+`%APPDATA%\Claude\claude_desktop_config.json` on Windows, `$XDG_CONFIG_HOME/Claude/...` or
+`~/.config/Claude/...` elsewhere). Project files come first so a project-scoped list wins over a
+machine-wide one. When none exists, `init` exits 1 and prints every path it looked at.
+
+Each imported server keeps its `command`/`args`/`env` or `url`/`headers` and gets an `output` of
+`<out-dir>/<alias>.introspection.d.ts`, where `<out-dir>` is `--out-dir`, or `src` when that
+directory exists, or the current directory. Characters in an alias that are not letters, digits,
+`.`, `_`, or `-` become `-` in the file name; the alias itself is kept as the config key. An entry
+with neither `command` nor `url` is skipped with a warning.
+
+`env` and `headers` are copied verbatim. Keys that look like secrets (`key`, `token`, `secret`,
+`password`, `authorization`, `credential`, case-insensitive) are named in a warning, since the
+config is meant to be committed. `--config` changes where the file is written (default
+`mcp-tada.config.json`); an existing file is refused unless `--force` is given, and an identical
+file is left untouched. On success the imported aliases and the next commands to run are printed
+to stderr.
+
+## `mcp-tada doctor`
+
+```
+mcp-tada doctor [--config <path>] [--offline] [--timeout <ms>]
+```
+
+Runs the setup checks in order and prints one line per check, prefixed `ok`, `warn`, or `fail`:
+
+- `@modelcontextprotocol/sdk` is installed (`fail` otherwise) and at least 1.20.0 (`warn`
+  otherwise); `typescript` is installed and at least 5.4.0 (`warn` otherwise). Both are found by
+  looking for `node_modules/<name>/package.json` in the current directory and its parents.
+- The config (`--config`, default `mcp-tada.config.json`) exists and loads (`fail` otherwise),
+  and configures at least one server (`warn` otherwise).
+- No two servers share an `output` (`fail`), and every server has a `command` or `url` (`fail`).
+- Each server's snapshot exists (`warn` with the `introspect` command to run otherwise) and
+  parses back (`fail` otherwise).
+- Unless `--offline`, each server is connected to and its tools listed. A server that answers is
+  `ok`, with its name, version, and tool count, and `warn` when the live tools differ from the
+  snapshot (with the `check` command to run). A server that cannot be reached is `fail`.
+  `--timeout <ms>` applies to each connect and list, with a server's `timeoutMs` in the config
+  taking precedence; the default is 30000.
+
+The exit code is 1 when any check is `fail`, and 0 otherwise. Warnings never change it, so
+`doctor` can run before the first `introspect`.
 
 ## `mcp-tada introspect`
 
@@ -261,3 +314,10 @@ The building blocks are exported too, for tooling that wants to compose its own 
 (`buildIntrospectionData`, `formatDts` and `formatJson` take that `{ tools, prompts? }` source, or
 a bare `Tool[]`); `diffIntrospection` and `formatReport` on the check side; and
 `parseSnapshotText`, `parseDtsSnapshot`, and `detectFormat` for reading a snapshot back.
+
+`init(options)` and `doctor(options)` are exported as well. `init` takes `cwd`, `from`, `outDir`,
+`configPath`, `force`, and `write` (false to only compute), and returns `{ configPath, source,
+config, text, wrote, warnings }`; `candidateSources(cwd)` lists the files it would search.
+`doctor` takes `cwd`, `configPath`, `connect` (false for `--offline`), and `timeoutMs`, and
+returns `{ checks, ok, text }`, where each check is `{ status, subject, detail }` with `status`
+one of `"ok"`, `"warn"`, or `"fail"`, and `ok` is false when any check failed.

--- a/packages/mcp-tada/src/cli/doctor.ts
+++ b/packages/mcp-tada/src/cli/doctor.ts
@@ -1,0 +1,247 @@
+// `mcp-tada doctor`: the setup checks people otherwise discover one failed command at a time.
+// Installed package versions, the config file, each server's snapshot, and (unless offline)
+// whether each server answers and still matches its snapshot.
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import {
+  DEFAULT_TIMEOUT_MS,
+  loadConfig,
+  type McpTadaConfig,
+  type ServerConfigEntry,
+  type ServerTarget,
+} from "./connect.js";
+import { diffIntrospection } from "./check.js";
+import { DEFAULT_CONFIG_PATH } from "./init.js";
+import { buildIntrospectionData, introspectTarget } from "./introspect.js";
+import { detectFormat, parseSnapshotText } from "./snapshot.js";
+
+export type DoctorStatus = "ok" | "warn" | "fail";
+
+export interface DoctorCheck {
+  status: DoctorStatus;
+  /** What was checked, e.g. `@modelcontextprotocol/sdk` or a server alias. */
+  subject: string;
+  detail: string;
+}
+
+export interface DoctorOptions {
+  /** Directory the config and snapshots are resolved from, and packages are resolved for.
+   * Defaults to `process.cwd()`. */
+  cwd?: string;
+  /** Config path, relative to `cwd`. Defaults to `mcp-tada.config.json`. */
+  configPath?: string;
+  /** Set false to skip connecting to the configured servers. */
+  connect?: boolean;
+  /** Connect and list timeout for the reachability check; a server's `timeoutMs` wins when set. */
+  timeoutMs?: number;
+}
+
+export interface DoctorResult {
+  checks: DoctorCheck[];
+  /** False when any check failed. Warnings do not affect it. */
+  ok: boolean;
+  text: string;
+}
+
+/** Minimum SDK the client is tested against; matches the `peerDependencies` range. */
+export const MIN_SDK_VERSION = "1.20.0";
+/** `const` type parameters, which the server package relies on, arrived in TypeScript 5.0;
+ * 5.4 is the tested floor and the `peerDependencies` range. */
+export const MIN_TYPESCRIPT_VERSION = "5.4.0";
+
+/** `a` is at least `b`, comparing the leading `major.minor.patch` of each. */
+export function versionAtLeast(a: string, b: string): boolean {
+  const parse = (v: string) => (v.match(/^(\d+)\.(\d+)\.(\d+)/) ?? []).slice(1, 4).map(Number);
+  const [am = 0, an = 0, ap = 0] = parse(a);
+  const [bm = 0, bn = 0, bp = 0] = parse(b);
+  return am !== bm ? am > bm : an !== bn ? an > bn : ap >= bp;
+}
+
+/** Version of `name` as installed for `cwd`, or `undefined` when it is not. Looks for
+ * `node_modules/<name>/package.json` in `cwd` and each parent, the same directories Node's
+ * resolver would search, but reads the manifest directly since the SDK does not export it. */
+export function installedVersion(name: string, cwd: string): string | undefined {
+  let dir = resolve(cwd);
+  for (;;) {
+    const manifest = join(dir, "node_modules", name, "package.json");
+    if (existsSync(manifest)) {
+      try {
+        const pkg = JSON.parse(readFileSync(manifest, "utf8")) as { version?: string };
+        if (typeof pkg.version === "string") return pkg.version;
+      } catch {
+        // unreadable manifest; keep looking further up
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+function toTarget(entry: ServerConfigEntry, timeoutMs: number | undefined): ServerTarget {
+  const target: ServerTarget = {};
+  if (entry.command !== undefined) target.command = entry.command;
+  if (entry.args !== undefined) target.args = entry.args;
+  if (entry.env !== undefined) target.env = entry.env;
+  if (entry.url !== undefined) target.url = entry.url;
+  if (entry.headers !== undefined) target.headers = entry.headers;
+  target.timeoutMs = entry.timeoutMs ?? timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  return target;
+}
+
+export async function doctor(opts: DoctorOptions = {}): Promise<DoctorResult> {
+  const cwd = opts.cwd ?? process.cwd();
+  const checks: DoctorCheck[] = [];
+  const push = (status: DoctorStatus, subject: string, detail: string) =>
+    checks.push({ status, subject, detail });
+
+  const sdk = installedVersion("@modelcontextprotocol/sdk", cwd);
+  if (sdk === undefined) {
+    push(
+      "fail",
+      "@modelcontextprotocol/sdk",
+      "not installed (it is a peer dependency of mcp-tada)",
+    );
+  } else if (!versionAtLeast(sdk, MIN_SDK_VERSION)) {
+    push(
+      "warn",
+      "@modelcontextprotocol/sdk",
+      `${sdk} installed, ${MIN_SDK_VERSION} or newer expected`,
+    );
+  } else {
+    push("ok", "@modelcontextprotocol/sdk", sdk);
+  }
+
+  const ts = installedVersion("typescript", cwd);
+  if (ts === undefined) {
+    push(
+      "warn",
+      "typescript",
+      "not installed; the typed client is type-level only, so nothing is checked",
+    );
+  } else if (!versionAtLeast(ts, MIN_TYPESCRIPT_VERSION)) {
+    push("warn", "typescript", `${ts} installed, ${MIN_TYPESCRIPT_VERSION} or newer expected`);
+  } else {
+    push("ok", "typescript", ts);
+  }
+
+  const configRel = opts.configPath ?? DEFAULT_CONFIG_PATH;
+  const configPath = resolve(cwd, configRel);
+  let config: McpTadaConfig | undefined;
+  if (!existsSync(configPath)) {
+    push("fail", configRel, "not found (run `mcp-tada init`, or pass --config)");
+  } else {
+    try {
+      config = loadConfig(configPath);
+      const n = Object.keys(config.servers).length;
+      push(
+        n === 0 ? "warn" : "ok",
+        configRel,
+        n === 0 ? "configures no servers" : `${n} server${n === 1 ? "" : "s"}`,
+      );
+    } catch (err) {
+      push("fail", configRel, (err as Error).message);
+    }
+  }
+
+  if (config !== undefined) {
+    const outputs = new Map<string, string[]>();
+    for (const [alias, entry] of Object.entries(config.servers)) {
+      if (entry.output !== undefined) {
+        const key = resolve(cwd, entry.output);
+        outputs.set(key, [...(outputs.get(key) ?? []), alias]);
+      }
+    }
+    for (const [output, aliases] of outputs) {
+      if (aliases.length > 1) {
+        push(
+          "fail",
+          aliases.join(", "),
+          `share the output ${relative(cwd, output)}; each server needs its own`,
+        );
+      }
+    }
+
+    for (const [alias, entry] of Object.entries(config.servers)) {
+      if (entry.command === undefined && entry.url === undefined) {
+        push("fail", alias, 'has neither "command" nor "url"');
+        continue;
+      }
+      let snapshot: ReturnType<typeof parseSnapshotText> | undefined;
+      if (entry.output === undefined) {
+        push(
+          "warn",
+          alias,
+          'no "output"; introspect will write <alias>.introspection.d.ts in the current directory',
+        );
+      } else {
+        const snapshotPath = resolve(cwd, entry.output);
+        if (!existsSync(snapshotPath)) {
+          push(
+            "warn",
+            alias,
+            `snapshot ${entry.output} not found (run \`mcp-tada introspect ${alias}\`)`,
+          );
+        } else {
+          try {
+            snapshot = parseSnapshotText(
+              readFileSync(snapshotPath, "utf8"),
+              detectFormat(snapshotPath),
+            );
+            push(
+              "ok",
+              alias,
+              `snapshot ${entry.output}, ${Object.keys(snapshot.tools).length} tools`,
+            );
+          } catch (err) {
+            push(
+              "fail",
+              alias,
+              `snapshot ${entry.output} cannot be read back (${(err as Error).message}); regenerate it, and keep formatters off it`,
+            );
+          }
+        }
+      }
+      if (opts.connect === false) continue;
+      try {
+        const { meta, ...source } = await introspectTarget(toTarget(entry, opts.timeoutMs));
+        const live = buildIntrospectionData(source);
+        const name =
+          meta.serverName !== undefined
+            ? `${meta.serverName}@${meta.serverVersion ?? "?"}`
+            : "server";
+        const count = Object.keys(live.tools).length;
+        if (snapshot === undefined) {
+          push("ok", alias, `reachable: ${name}, ${count} tools`);
+        } else if (diffIntrospection(snapshot, live).identical) {
+          push("ok", alias, `reachable: ${name}, ${count} tools, snapshot up to date`);
+        } else {
+          push(
+            "warn",
+            alias,
+            `reachable: ${name}, ${count} tools, snapshot differs (run \`mcp-tada check ${alias}\`)`,
+          );
+        }
+      } catch (err) {
+        push("fail", alias, `unreachable: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  const ok = checks.every((c) => c.status !== "fail");
+  return { checks, ok, text: formatDoctorReport(checks) };
+}
+
+export function formatDoctorReport(checks: DoctorCheck[]): string {
+  const lines = ["mcp-tada doctor"];
+  for (const c of checks) lines.push(`  ${c.status.padEnd(4)}  ${c.subject}: ${c.detail}`);
+  const fails = checks.filter((c) => c.status === "fail").length;
+  const warns = checks.filter((c) => c.status === "warn").length;
+  lines.push(
+    fails === 0 && warns === 0
+      ? "all checks passed"
+      : `${fails} failed, ${warns} warning${warns === 1 ? "" : "s"}`,
+    "",
+  );
+  return lines.join("\n");
+}

--- a/packages/mcp-tada/src/cli/index.ts
+++ b/packages/mcp-tada/src/cli/index.ts
@@ -39,6 +39,25 @@ export {
   type CheckRunResult,
 } from "./check.js";
 export {
+  DEFAULT_CONFIG_PATH,
+  candidateSources,
+  init,
+  type InitOptions,
+  type InitResult,
+} from "./init.js";
+export {
+  MIN_SDK_VERSION,
+  MIN_TYPESCRIPT_VERSION,
+  doctor,
+  formatDoctorReport,
+  installedVersion,
+  versionAtLeast,
+  type DoctorCheck,
+  type DoctorOptions,
+  type DoctorResult,
+  type DoctorStatus,
+} from "./doctor.js";
+export {
   detectFormat,
   parseDtsSnapshot,
   parseSnapshotText,

--- a/packages/mcp-tada/src/cli/init.ts
+++ b/packages/mcp-tada/src/cli/init.ts
@@ -1,0 +1,129 @@
+// `mcp-tada init`: write an `mcp-tada.config.json` from the MCP servers a project already
+// configures for its editor or agent, so the first `mcp-tada introspect` needs no flags.
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, relative, resolve } from "node:path";
+import { loadConfig, type McpTadaConfig, type ServerConfigEntry } from "./connect.js";
+import { writeIfChanged } from "./introspect.js";
+
+export const DEFAULT_CONFIG_PATH = "mcp-tada.config.json";
+
+/** Files consulted, in order, when `--from` is not given. Project files first, then the user's
+ * Claude Desktop config, so a project-scoped server list wins over a machine-wide one. */
+export function candidateSources(cwd: string, platform = process.platform, home = homedir()) {
+  const project = [".mcp.json", join(".cursor", "mcp.json"), join(".vscode", "mcp.json")].map((p) =>
+    join(cwd, p),
+  );
+  const desktop =
+    platform === "darwin"
+      ? join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json")
+      : platform === "win32"
+        ? join(
+            process.env["APPDATA"] ?? join(home, "AppData", "Roaming"),
+            "Claude",
+            "claude_desktop_config.json",
+          )
+        : join(
+            process.env["XDG_CONFIG_HOME"] ?? join(home, ".config"),
+            "Claude",
+            "claude_desktop_config.json",
+          );
+  return [...project, desktop];
+}
+
+export interface InitOptions {
+  /** Directory the config is written to and paths are resolved from. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /** A specific file to import servers from, instead of searching the candidates. */
+  from?: string;
+  /** Where each server's snapshot goes, relative to `cwd`. Defaults to `src` when it exists. */
+  outDir?: string;
+  /** Path of the config to write, relative to `cwd`. Defaults to `mcp-tada.config.json`. */
+  configPath?: string;
+  /** Overwrite an existing config. */
+  force?: boolean;
+  /** Set false to skip writing to disk. */
+  write?: boolean;
+}
+
+export interface InitResult {
+  configPath: string;
+  /** The file the servers were imported from. */
+  source: string;
+  config: McpTadaConfig;
+  text: string;
+  wrote: boolean;
+  /** Human-readable notes, e.g. env values that were copied verbatim. */
+  warnings: string[];
+}
+
+const secretLike = /key|token|secret|password|authorization|credential/i;
+
+function snapshotFileName(alias: string): string {
+  return `${alias.replace(/[^A-Za-z0-9._-]+/g, "-")}.introspection.d.ts`;
+}
+
+/** Import servers from an existing MCP config and write `mcp-tada.config.json`. Throws when the
+ * config already exists (without `force`) or when no source can be found. */
+export function init(opts: InitOptions = {}): InitResult {
+  const cwd = opts.cwd ?? process.cwd();
+  const configPath = resolve(cwd, opts.configPath ?? DEFAULT_CONFIG_PATH);
+  if (existsSync(configPath) && !opts.force) {
+    throw new Error(
+      `mcp-tada init: ${relative(cwd, configPath) || configPath} already exists (pass --force to overwrite)`,
+    );
+  }
+
+  let source: string | undefined;
+  if (opts.from !== undefined) {
+    source = resolve(cwd, opts.from);
+    if (!existsSync(source)) throw new Error(`mcp-tada init: ${opts.from} does not exist`);
+  } else {
+    const candidates = candidateSources(cwd);
+    source = candidates.find((p) => existsSync(p));
+    if (source === undefined) {
+      throw new Error(
+        `mcp-tada init: no MCP config found. Looked for:\n${candidates.map((p) => `  ${p}`).join("\n")}\n` +
+          `Pass --from <path> to import a specific file.`,
+      );
+    }
+  }
+
+  const imported = loadConfig(source);
+  const aliases = Object.keys(imported.servers);
+  if (aliases.length === 0) {
+    throw new Error(`mcp-tada init: ${source} configures no servers`);
+  }
+
+  const outDir = opts.outDir ?? (existsSync(join(cwd, "src")) ? "src" : ".");
+  const warnings: string[] = [];
+  const servers: Record<string, ServerConfigEntry> = {};
+  for (const alias of aliases) {
+    const entry = imported.servers[alias] as ServerConfigEntry;
+    if (entry.command === undefined && entry.url === undefined) {
+      warnings.push(`${alias}: skipped, it has neither "command" nor "url"`);
+      continue;
+    }
+    const secrets = [...Object.keys(entry.env ?? {}), ...Object.keys(entry.headers ?? {})].filter(
+      (k) => secretLike.test(k),
+    );
+    if (secrets.length > 0) {
+      warnings.push(
+        `${alias}: copied ${secrets.join(", ")} verbatim; keep secrets out of a committed config`,
+      );
+    }
+    const { output: _ignored, ...rest } = entry;
+    const output = join(outDir, snapshotFileName(alias)).split("\\").join("/");
+    servers[alias] = { ...rest, output: output.startsWith("./") ? output.slice(2) : output };
+  }
+  if (Object.keys(servers).length === 0) {
+    throw new Error(
+      `mcp-tada init: none of the servers in ${source} can be reached (no command or url)`,
+    );
+  }
+
+  const config: McpTadaConfig = { servers };
+  const text = `${JSON.stringify(config, null, 2)}\n`;
+  const wrote = (opts.write ?? true) ? writeIfChanged(configPath, text) : false;
+  return { configPath, source, config, text, wrote, warnings };
+}

--- a/packages/mcp-tada/src/cli/main.ts
+++ b/packages/mcp-tada/src/cli/main.ts
@@ -15,14 +15,22 @@ import {
 } from "./connect.js";
 import { introspect } from "./introspect.js";
 import { check } from "./check.js";
+import { init } from "./init.js";
+import { doctor } from "./doctor.js";
 
 const HELP = `mcp-tada: typed tool calls derived from a live server's tools/list
 
 Usage:
+  mcp-tada init [--from <path>] [--out-dir <dir>] [--force]
+  mcp-tada doctor [--config <path>] [--offline] [--timeout <ms>]
   mcp-tada introspect [target flags] [--out <path>] [--name <TypeName>] [--json] [--verbose]
   mcp-tada check [target flags] --against <path>
   mcp-tada --help
   mcp-tada --version
+
+init writes mcp-tada.config.json from the servers in .mcp.json, .cursor/mcp.json, .vscode/mcp.json
+or the Claude Desktop config (first found), or from --from <path>. doctor checks installed
+versions, the config, every snapshot, and (unless --offline) that each server answers.
 
 Target flags (one of):
   --command "node server.js"     stdio server, whitespace-split like --stdio
@@ -292,6 +300,98 @@ async function runCheck(argv: string[]): Promise<number> {
   return runCheckWith({ ...values, aliasFilter: positionals[0] });
 }
 
+export interface RunInitArgs {
+  from?: string;
+  "out-dir"?: string;
+  force?: boolean;
+  config?: string;
+  help?: boolean;
+}
+
+/** Core of `mcp-tada init`: import servers into a config and print what to do next. */
+export function runInitWith(values: RunInitArgs): number {
+  if (values.help) {
+    console.log(HELP);
+    return 0;
+  }
+  let result;
+  try {
+    result = init({
+      ...(values.from !== undefined ? { from: values.from } : {}),
+      ...(values["out-dir"] !== undefined ? { outDir: values["out-dir"] } : {}),
+      ...(values.config !== undefined ? { configPath: values.config } : {}),
+      ...(values.force !== undefined ? { force: values.force } : {}),
+    });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+  const aliases = Object.keys(result.config.servers);
+  console.error(`mcp-tada init: imported ${aliases.join(", ")} from ${result.source}`);
+  for (const warning of result.warnings) console.error(`mcp-tada init: ${warning}`);
+  console.error(
+    "\nNext:\n  mcp-tada introspect        # write each server's snapshot\n" +
+      "  mcp-tada check             # in CI, fail when a server drifts from its snapshot",
+  );
+  return 0;
+}
+
+async function runInit(argv: string[]): Promise<number> {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      from: { type: "string" },
+      "out-dir": { type: "string" },
+      force: { type: "boolean" },
+      config: { type: "string" },
+      help: { type: "boolean" },
+    },
+  });
+  return runInitWith(values);
+}
+
+export interface RunDoctorArgs {
+  config?: string;
+  offline?: boolean;
+  timeout?: string;
+  help?: boolean;
+}
+
+/** Core of `mcp-tada doctor`: exit 1 when any check fails; warnings alone exit 0. */
+export async function runDoctorWith(values: RunDoctorArgs): Promise<number> {
+  if (values.help) {
+    console.log(HELP);
+    return 0;
+  }
+  let timeoutMs: number | undefined;
+  try {
+    timeoutMs = parseTimeoutFlag(values.timeout);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+  const result = await doctor({
+    ...(values.config !== undefined ? { configPath: values.config } : {}),
+    ...(values.offline ? { connect: false } : {}),
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+  });
+  process.stdout.write(result.text);
+  return result.ok ? 0 : 1;
+}
+
+async function runDoctor(argv: string[]): Promise<number> {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      config: { type: "string" },
+      offline: { type: "boolean" },
+      timeout: { type: "string" },
+      help: { type: "boolean" },
+    },
+  });
+  return runDoctorWith(values);
+}
+
 function readVersion(): string {
   try {
     const here = dirname(fileURLToPath(import.meta.url));
@@ -314,6 +414,10 @@ async function main(argv: string[]): Promise<number> {
     return 0;
   }
   switch (sub) {
+    case "init":
+      return runInit(rest);
+    case "doctor":
+      return runDoctor(rest);
     case "introspect":
       return runIntrospect(rest);
     case "check":

--- a/packages/mcp-tada/test/init-doctor.test.ts
+++ b/packages/mcp-tada/test/init-doctor.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { candidateSources, init } from "../src/cli/init.js";
+import { doctor, installedVersion, versionAtLeast } from "../src/cli/doctor.js";
+
+const EVERYTHING_SERVER = resolve(
+  "node_modules/@modelcontextprotocol/server-everything/dist/index.js",
+);
+
+function tmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "mcp-tada-init-test-"));
+}
+
+describe("init", () => {
+  it("imports a Claude Code .mcp.json and gives each server a snapshot under src", () => {
+    const cwd = tmpDir();
+    mkdirSync(join(cwd, "src"));
+    writeFileSync(
+      join(cwd, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          everything: { command: "node", args: [EVERYTHING_SERVER], env: { API_TOKEN: "x" } },
+          "remote api": { url: "https://example.com/mcp", headers: { Authorization: "Bearer y" } },
+          broken: { disabled: true },
+        },
+      }),
+    );
+    const result = init({ cwd });
+    expect(result.wrote).toBe(true);
+    expect(result.source).toBe(join(cwd, ".mcp.json"));
+    expect(result.config).toEqual({
+      servers: {
+        everything: {
+          command: "node",
+          args: [EVERYTHING_SERVER],
+          env: { API_TOKEN: "x" },
+          output: "src/everything.introspection.d.ts",
+        },
+        "remote api": {
+          url: "https://example.com/mcp",
+          headers: { Authorization: "Bearer y" },
+          output: "src/remote-api.introspection.d.ts",
+        },
+      },
+    });
+    expect(result.warnings).toEqual([
+      "everything: copied API_TOKEN verbatim; keep secrets out of a committed config",
+      "remote api: copied Authorization verbatim; keep secrets out of a committed config",
+      'broken: skipped, it has neither "command" nor "url"',
+    ]);
+    expect(JSON.parse(readFileSync(join(cwd, "mcp-tada.config.json"), "utf8"))).toEqual(
+      result.config,
+    );
+    expect(() => init({ cwd })).toThrow("already exists");
+    expect(init({ cwd, force: true }).wrote).toBe(false);
+  });
+
+  it("prefers project files over the desktop config, and reports what it looked for", () => {
+    const cwd = tmpDir();
+    const [first, , , desktop] = candidateSources(cwd, "darwin", "/home/x");
+    expect(first).toBe(join(cwd, ".mcp.json"));
+    expect(desktop).toBe("/home/x/Library/Application Support/Claude/claude_desktop_config.json");
+    expect(() => init({ cwd, write: false })).toThrow(join(cwd, ".cursor", "mcp.json"));
+    expect(existsSync(join(cwd, "mcp-tada.config.json"))).toBe(false);
+  });
+
+  it("imports a VS Code style file through --from without a src directory", () => {
+    const cwd = tmpDir();
+    writeFileSync(
+      join(cwd, "servers.json"),
+      JSON.stringify({ servers: { fs: { type: "stdio", command: "npx", args: ["-y", "x"] } } }),
+    );
+    const result = init({ cwd, from: "servers.json", write: false });
+    expect(result.config.servers["fs"]?.output).toBe("fs.introspection.d.ts");
+    expect(result.warnings).toEqual([]);
+  });
+});
+
+describe("doctor", () => {
+  it("compares versions by major.minor.patch", () => {
+    expect(versionAtLeast("1.30.0", "1.20.0")).toBe(true);
+    expect(versionAtLeast("1.9.9", "1.20.0")).toBe(false);
+    expect(versionAtLeast("7.0.2-beta", "5.4.0")).toBe(true);
+    expect(installedVersion("@modelcontextprotocol/sdk", process.cwd())).toMatch(/^\d+\.\d+\.\d+/);
+    expect(installedVersion("no-such-package", process.cwd())).toBeUndefined();
+  });
+
+  it("reports a missing config as a failure", async () => {
+    const cwd = tmpDir();
+    const result = await doctor({ cwd, connect: false });
+    expect(result.ok).toBe(false);
+    const byStatus = Object.fromEntries(result.checks.map((c) => [c.subject, c.status]));
+    expect(byStatus["@modelcontextprotocol/sdk"]).toBe("fail");
+    expect(byStatus["typescript"]).toBe("warn");
+    expect(byStatus["mcp-tada.config.json"]).toBe("fail");
+    expect(result.text).toContain("mcp-tada init");
+  });
+
+  it("checks packages, snapshots, duplicate outputs, and reachability", async () => {
+    const cwd = tmpDir();
+    const configPath = join(cwd, "mcp-tada.config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        servers: {
+          everything: {
+            command: "node",
+            args: [EVERYTHING_SERVER],
+            output: join(cwd, "everything.introspection.d.ts"),
+          },
+          dupA: { url: "https://127.0.0.1:9/mcp", output: join(cwd, "dup.d.ts"), timeoutMs: 2000 },
+          dupB: { url: "https://127.0.0.1:9/mcp", output: join(cwd, "dup.d.ts"), timeoutMs: 2000 },
+          corrupt: {
+            url: "https://127.0.0.1:9/mcp",
+            output: join(cwd, "corrupt.d.ts"),
+            timeoutMs: 2000,
+          },
+        },
+      }),
+    );
+    // A snapshot a formatter has unquoted is exactly what the parser must reject.
+    writeFileSync(join(cwd, "corrupt.d.ts"), "export type introspection = { tools: {} };\n");
+
+    const result = await doctor({ cwd: process.cwd(), configPath });
+    const bySubject = (subject: string) => result.checks.filter((c) => c.subject === subject);
+    const one = (subject: string) => {
+      const found = bySubject(subject);
+      expect(found).toHaveLength(1);
+      return found[0];
+    };
+    expect(one("@modelcontextprotocol/sdk")?.status).toBe("ok");
+    expect(one("typescript")?.status).toBe("ok");
+    expect(bySubject("mcp-tada.config.json")).toEqual([]);
+    expect(one(configPath)?.detail).toBe("4 servers");
+    expect(one("dupA, dupB")?.status).toBe("fail");
+    expect(bySubject("corrupt").map((c) => c.status)).toEqual(["fail", "fail"]);
+    expect(bySubject("corrupt")[0]?.detail).toContain("cannot be read back");
+    expect(bySubject("dupA").map((c) => c.status)).toEqual(["warn", "fail"]);
+    expect(bySubject("dupA")[1]?.detail).toContain("unreachable");
+    expect(result.ok).toBe(false);
+
+    const everything = result.checks.filter((c) => c.subject === "everything");
+    expect(everything.map((c) => c.status)).toEqual(["warn", "ok"]);
+    expect(everything[0]?.detail).toContain("not found");
+    expect(everything[1]?.detail).toMatch(/^reachable: .*everything@\S+, \d+ tools$/);
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

- `mcp-tada init [--from <path>] [--out-dir <dir>] [--config <path>] [--force]` writes `mcp-tada.config.json` from the first of `.mcp.json`, `.cursor/mcp.json`, `.vscode/mcp.json`, or the Claude Desktop config, or from `--from`. Each server gets an `output` under `src/` when that directory exists. `env` and `headers` are copied verbatim, with a warning naming any key that looks like a secret. It refuses to overwrite without `--force` and exits 1 listing every path it searched when nothing is found.
- `mcp-tada doctor [--config <path>] [--offline] [--timeout <ms>]` prints one `ok`/`warn`/`fail` line per check: installed `@modelcontextprotocol/sdk` (>= 1.20.0) and `typescript` (>= 5.4.0), the config loads, no two servers share an `output`, every snapshot exists and parses back, and unless `--offline` each server answers and its live tools match the snapshot. Exit 1 on any `fail`; warnings alone exit 0.
- Packages are located by walking up for `node_modules/<name>/package.json`, since the SDK does not export its manifest.
- Both are exported from `mcp-tada/cli` (`init`, `doctor`, `candidateSources`, `formatDoctorReport`, `installedVersion`, `versionAtLeast`).

## Testing

- [x] `pnpm run verify` (format, lint, build, typecheck, test)
- Also ran `init`, `doctor`, and `introspect` end to end through the built binary in a scratch project.

## Checklist

- [x] Docs updated if needed
- [x] Concise, user-facing changeset added if the published package changed