### PR TITLE
Classify check differences by severity and add --fail-on

### DIFF
--- a/.changeset/breaking-check.md
+++ b/.changeset/breaking-check.md
@@ -1,0 +1,10 @@
+---
+"mcp-tada": minor
+---
+
+`mcp-tada check` now rates every difference as additive, dangerous (a tool withdrew a safety hint
+such as `readOnlyHint`), or breaking, groups the report by severity, and takes
+`--fail-on <any|dangerous|breaking>` to choose which of those exits 1. A schema difference is
+judged by direction: tightening an `inputSchema` or loosening an `outputSchema` breaks callers,
+the reverse is additive. `report.severity` and `report.changes` expose the same classification
+to the programmatic API, and `compareSchemas` is exported for diffing two schemas on their own.

--- a/README.md
+++ b/README.md
@@ -102,10 +102,32 @@ Flags: `--stdio` or `--command` plus repeatable `--arg` and `--env KEY=VAL`; `--
 
 ### `mcp-tada check`
 
-Diffs a live server against a snapshot and exits 1 on any drift: added or removed tools, changed input schemas, changed or newly present output schemas, changed annotations, and added, removed, or re-argued prompts. A tool that stopped being read-only or non-destructive is called out on its own line, since code written against the old snapshot may be trusting that hint. Run it in CI. Accepts the same target flags as `introspect`, including `--timeout <ms>`.
+Diffs a live server against a snapshot and exits 1 on any drift: added or removed tools, changed input schemas, changed or newly present output schemas, changed annotations, and added, removed, or re-argued prompts. Run it in CI. Accepts the same target flags as `introspect`, including `--timeout <ms>`.
 
 ```sh
 mcp-tada check --stdio "npx -y @modelcontextprotocol/server-filesystem ." --against src/fs.introspection.d.ts
+```
+
+Each difference gets a severity, and the report is grouped by it, with the reason underneath:
+
+```
+mcp-tada check: differences from src/fs.introspection.d.ts (1 breaking, 1 dangerous, 1 additive)
+  breaking:
+    search: inputSchema changed
+      .limit: is now required
+  dangerous:
+    delete-file: lost a safety guarantee
+      destructiveHint is no longer false
+  additive:
+    summarize: added tool
+```
+
+Breaking means code written against the snapshot can stop working: a tool or prompt that went away, a newly required argument, an input schema that got stricter, an output schema that got looser. Direction matters, so the same edit is breaking on the way in and additive on the way out. Dangerous means the contract still holds but a tool withdrew a promise: it stopped being read-only, idempotent, non-destructive, or closed-world. Anything `check` cannot model counts as breaking rather than being waved through.
+
+`--fail-on <level>` sets the least severe difference that fails the build: `any` (the default), `dangerous`, or `breaking`. Milder drift is still printed. `dangerous` is the setting for a server you do not control and that ships new tools regularly.
+
+```sh
+mcp-tada check --fail-on dangerous
 ```
 
 ### Config file
@@ -174,7 +196,7 @@ The snapshot is a committed file, and the commands map onto the moments where it
 - **Setup.** List each server and its `output` in `mcp-tada.config.json`, then run `mcp-tada introspect` to write one snapshot per server. Commit the snapshots.
 - **Editing.** Types come from the committed snapshot, so nothing runs while you edit. Re-run `introspect` when you upgrade a server or change one you author; the file is left alone when nothing changed, so it is cheap to run often.
 - **Committing.** The snapshot changes only when a server's contract does, which makes its diff a review artifact: a widened input, a new `outputSchema`, or a tool that stopped being read-only shows up in the pull request next to the code that relies on it.
-- **CI.** Run `mcp-tada check` to fail when a live server has drifted from the snapshot, and `mcp-tada introspect` followed by `git diff --exit-code` to fail when someone forgot to commit a regenerated one. Both need the servers reachable from CI, so put secrets in `env` through the runner's environment rather than in the config.
+- **CI.** Run `mcp-tada check` to fail when a live server has drifted from the snapshot (or `mcp-tada check --fail-on dangerous` to ignore drift that only adds things), and `mcp-tada introspect` followed by `git diff --exit-code` to fail when someone forgot to commit a regenerated one. Both need the servers reachable from CI, so put secrets in `env` through the runner's environment rather than in the config.
 
 ```yaml
 - run: pnpm mcp-tada introspect

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -206,22 +206,65 @@ mcp-tada check --command "node server.js" --against introspection.d.ts
 `introspect --json`; the format is inferred from the extension. Target flags are the same as
 `introspect`.
 
-The report lists, when present:
+The report covers added and removed tools, tools whose `inputSchema`, `outputSchema` or
+`annotations` changed, and added, removed or re-argued prompts. A snapshot without a `prompts`
+key is diffed as having none, so a server that offers prompts shows them all as added until the
+snapshot is regenerated.
 
-- added tools (live but not in the snapshot)
-- removed tools (in the snapshot but no longer live)
-- tools whose `inputSchema` changed
-- tools whose `outputSchema` appeared, disappeared, or changed shape
-- tools whose `annotations` appeared, disappeared, or changed, and, on a separate line, the
-  subset that lost a safety guarantee: `readOnlyHint` was `true` and no longer is, or
-  `destructiveHint` was `false` and no longer is
-- added and removed prompts, and prompts whose argument list changed (names, order, or
-  `required` flags). A snapshot without a `prompts` key is diffed as having none, so a server
-  that offers prompts shows them all as added until the snapshot is regenerated.
+Every difference gets a severity, and the report is grouped by it, worst first, with the reason
+under each entry:
+
+- **breaking**: code written against the snapshot can stop working. A removed tool or prompt, a
+  disappeared `outputSchema`, a newly required prompt argument, or a schema change that goes the
+  wrong way.
+- **dangerous**: the contract still holds, but a behavioural guarantee was withdrawn. A tool
+  whose `readOnlyHint` or `idempotentHint` was `true` and no longer is, or whose
+  `destructiveHint` or `openWorldHint` was `false` and no longer is. Code that trusted the hint
+  still compiles and runs, which is exactly the problem.
+- **additive**: everything else. A new tool or prompt, a new optional property, a reworded
+  `description`, a looser input schema.
+
+```
+mcp-tada check: differences from src/introspection.d.ts (1 breaking, 1 dangerous, 2 additive)
+  breaking:
+    search: inputSchema changed
+      .limit: is now required
+      .cursor: property added (additive)
+  dangerous:
+    delete-file: lost a safety guarantee
+      destructiveHint is no longer false
+  additive:
+    search: outputSchema appeared
+    summarize: added tool
+```
+
+Schema direction decides which way is wrong. An `inputSchema` is written by the caller, so
+tightening it breaks calls (a new required property, a narrowed `type`, a shrunk `enum`, a
+stricter bound, `additionalProperties` turned off) while loosening it is additive. An
+`outputSchema` is read by the caller, so the rules invert: a property that is no longer required,
+a widened `type`, or a grown `enum` is breaking, and a new property or a tightened constraint is
+additive. A removed property is breaking in both directions. Anything `check` cannot model - an
+unrecognized keyword, a changed `$ref`, two incomparable `pattern`s - counts as breaking, so a
+schema it does not understand is never silently waved through. Changes to `description`,
+`title`, `default` and friends are additive, and so is reordering the values of an `enum`.
 
 Exit code is `1` if there is any difference, `0` if the live server matches the snapshot
 exactly. This makes `mcp-tada check --against introspection.d.ts` a good CI step to catch a
 server's tool contract drifting out from under your generated types.
+
+`--fail-on <level>` raises the bar: `--fail-on dangerous` exits `1` for dangerous and breaking
+differences, `--fail-on breaking` for breaking ones only, and `--fail-on any` (the default) for
+everything. Milder differences are still printed, and the run notes that it passed because of the
+flag. `dangerous` is the setting for a server you do not control and that adds tools regularly:
+it fails when the server takes something away or withdraws a promise, and stays quiet when it
+only gives you more.
+
+```
+mcp-tada check --fail-on dangerous
+```
+
+Since milder drift still leaves the snapshot stale, pair it with a scheduled job that runs
+`mcp-tada introspect` and commits the result, or run plain `mcp-tada check` on a nightly build.
 
 ## Config file
 
@@ -309,7 +352,14 @@ if (!report.identical) throw new Error(text);
 `name`, `json`, and `verbose` options as the flags. `check(options)` re-introspects and returns
 `{ report, text }`, where `report` has `added`, `removed`, `inputChanged`, `outputAppeared`,
 `outputDisappeared`, `outputChanged`, `annotationsChanged`, `safetyWeakened`, `promptsAdded`,
-`promptsRemoved`, `promptsChanged`, and `identical`.
+`promptsRemoved`, `promptsChanged`, and `identical`, plus `changes` and `severity`. `changes` is
+the same set of differences as one flat list, each `{ kind, subject, severity, summary, reasons }`
+with `severity` one of `"additive"`, `"dangerous"` or `"breaking"` and `kind` one of
+`"toolAdded"`, `"toolRemoved"`, `"inputSchema"`, `"outputSchemaAppeared"`,
+`"outputSchemaDisappeared"`, `"outputSchema"`, `"annotations"`, `"promptAdded"`,
+`"promptRemoved"` or `"promptArguments"`, ordered worst first. `report.severity` is the worst
+severity present (`"additive"` when the report is identical), which is what `--fail-on`
+compares against.
 
 A `ServerTarget` is `{ command?, args?, env?, url?, headers?, timeoutMs? }`, the normalized form of
 the target flags. Unlike the CLI, no default timeout is applied unless you set `timeoutMs`
@@ -323,6 +373,9 @@ The building blocks are exported too, for tooling that wants to compose its own 
 (`buildIntrospectionData`, `formatDts` and `formatJson` take that `{ tools, prompts? }` source, or
 a bare `Tool[]`); `diffIntrospection` and `formatReport` on the check side; and
 `parseSnapshotText`, `parseDtsSnapshot`, and `detectFormat` for reading a snapshot back.
+`compareSchemas(before, after, "input" | "output")` is the classifier on its own, returning
+`{ path, severity, message }` per difference, for tooling that wants to diff two schemas without
+a server.
 
 `init(options)` and `doctor(options)` are exported as well. `init` takes `cwd`, `from`, `outDir`,
 `configPath`, `force`, and `write` (false to only compute), and returns `{ configPath, source,

--- a/packages/mcp-tada/src/cli/check.ts
+++ b/packages/mcp-tada/src/cli/check.ts
@@ -1,13 +1,58 @@
 // `mcp-tada check`: re-introspect a live server and diff it against a previously generated
 // snapshot (a `.d.ts` from `introspect`, or a `--json` dump).
+//
+// Every difference gets a severity: additive (code written against the snapshot keeps working),
+// dangerous (it keeps working but a behavioural guarantee was withdrawn), or breaking. CI picks
+// the threshold with `--fail-on`. The schema-level rules live in `compat.ts`.
 import { readFileSync } from "node:fs";
+import {
+  bySeverity,
+  compareSchemas,
+  deepEqual,
+  diffKeys,
+  worstOf,
+  type SchemaChange,
+  type Severity,
+} from "./compat.js";
 import type { ServerTarget } from "./connect.js";
 import { buildIntrospectionData, introspectTarget } from "./introspect.js";
-import { detectFormat, parseSnapshotText, type IntrospectionData } from "./snapshot.js";
+import {
+  detectFormat,
+  parseSnapshotText,
+  type IntrospectionData,
+  type PromptArgumentSnapshot,
+  type ToolAnnotationsSnapshot,
+} from "./snapshot.js";
+
+export type { Severity } from "./compat.js";
 
 export interface CheckOptions {
   target: ServerTarget;
   against: string;
+}
+
+/** What kind of thing changed, for a consumer that wants to group or filter `changes`. */
+export type CheckChangeKind =
+  | "toolAdded"
+  | "toolRemoved"
+  | "inputSchema"
+  | "outputSchemaAppeared"
+  | "outputSchemaDisappeared"
+  | "outputSchema"
+  | "annotations"
+  | "promptAdded"
+  | "promptRemoved"
+  | "promptArguments";
+
+export interface CheckChange {
+  kind: CheckChangeKind;
+  /** The tool or prompt name the change belongs to. */
+  subject: string;
+  severity: Severity;
+  /** One line describing the change, e.g. `removed tool` or `inputSchema changed`. */
+  summary: string;
+  /** Why, one entry per underlying difference, worst first. Empty when `summary` says it all. */
+  reasons: string[];
 }
 
 export interface CheckReport {
@@ -19,13 +64,16 @@ export interface CheckReport {
   outputChanged: string[];
   /** Tools whose `annotations` differ in any way (appeared, disappeared, or changed). */
   annotationsChanged: string[];
-  /** The subset of `annotationsChanged` where a tool lost a safety guarantee: `readOnlyHint`
-   * went from `true` to anything else, or `destructiveHint` went from `false` to anything else. */
+  /** The subset of `annotationsChanged` where a tool withdrew a safety guarantee; see `SAFETY_HINTS`. */
   safetyWeakened: string[];
   promptsAdded: string[];
   promptsRemoved: string[];
   /** Prompts whose argument list (names, order, or `required` flags) changed. */
   promptsChanged: string[];
+  /** Every difference, classified. Ordered worst first, then by subject. */
+  changes: CheckChange[];
+  /** The worst severity among `changes`; `additive` when there are none (see `identical`). */
+  severity: Severity;
   identical: boolean;
 }
 
@@ -49,142 +97,195 @@ export function diffIntrospection(
   before: IntrospectionData,
   after: IntrospectionData,
 ): CheckReport {
-  const beforeNames = Object.keys(before.tools).sort();
-  const afterNames = Object.keys(after.tools).sort();
-  const beforeSet = new Set(beforeNames);
-  const afterSet = new Set(afterNames);
+  const changes: CheckChange[] = [];
+  const push = (
+    kind: CheckChangeKind,
+    subject: string,
+    summary: string,
+    severity: Severity,
+    details: Detail[] = [],
+  ): void => {
+    changes.push({ kind, subject, severity, summary, reasons: formatDetails(details, severity) });
+  };
+  /** A schema-level diff; no entries means only documentation keywords or set order differed. */
+  const pushSchema = (kind: CheckChangeKind, subject: string, details: SchemaChange[]): void => {
+    if (details.length === 0) {
+      push(kind, subject, `${kind} changed`, "additive", [
+        { severity: "additive", message: "documentation or ordering only" },
+      ]);
+    } else {
+      push(kind, subject, `${kind} changed`, worstOf(details), details);
+    }
+  };
 
-  const added = afterNames.filter((n) => !beforeSet.has(n));
-  const removed = beforeNames.filter((n) => !afterSet.has(n));
-
-  const inputChanged: string[] = [];
-  const outputAppeared: string[] = [];
-  const outputDisappeared: string[] = [];
-  const outputChangedInPlace: string[] = [];
-  const annotationsChanged: string[] = [];
-  const safetyWeakened: string[] = [];
-
-  for (const name of afterNames) {
-    if (!beforeSet.has(name)) continue;
+  const tools = diffKeys(before.tools, after.tools);
+  for (const name of tools.added) push("toolAdded", name, "added tool", "additive");
+  for (const name of tools.removed) push("toolRemoved", name, "removed tool", "breaking");
+  for (const name of tools.common) {
     const b = before.tools[name];
     const a = after.tools[name];
     if (!b || !a) continue;
-    if (!deepEqual(b.inputSchema, a.inputSchema)) inputChanged.push(name);
-
-    const bHasOut = b.outputSchema !== undefined;
-    const aHasOut = a.outputSchema !== undefined;
-    if (!bHasOut && aHasOut) outputAppeared.push(name);
-    else if (bHasOut && !aHasOut) outputDisappeared.push(name);
-    else if (bHasOut && aHasOut && !deepEqual(b.outputSchema, a.outputSchema)) {
-      outputChangedInPlace.push(name);
+    if (!deepEqual(b.inputSchema, a.inputSchema)) {
+      pushSchema("inputSchema", name, compareSchemas(b.inputSchema, a.inputSchema, "input"));
     }
-
+    if (b.outputSchema === undefined && a.outputSchema !== undefined) {
+      push("outputSchemaAppeared", name, "outputSchema appeared", "additive");
+    } else if (b.outputSchema !== undefined && a.outputSchema === undefined) {
+      push("outputSchemaDisappeared", name, "outputSchema disappeared", "breaking");
+    } else if (!deepEqual(b.outputSchema, a.outputSchema)) {
+      pushSchema("outputSchema", name, compareSchemas(b.outputSchema, a.outputSchema, "output"));
+    }
     if (!deepEqual(b.annotations, a.annotations)) {
-      annotationsChanged.push(name);
-      if (
-        (b.annotations?.readOnlyHint === true && a.annotations?.readOnlyHint !== true) ||
-        (b.annotations?.destructiveHint === false && a.annotations?.destructiveHint !== false)
-      ) {
-        safetyWeakened.push(name);
+      const weakened = weakenedHints(b.annotations, a.annotations);
+      if (weakened.length > 0) {
+        push("annotations", name, "lost a safety guarantee", "dangerous", weakened);
+      } else {
+        push("annotations", name, "annotations changed", "additive");
       }
     }
   }
-
-  const outputChanged = [...outputAppeared, ...outputDisappeared, ...outputChangedInPlace].sort();
 
   // A snapshot taken before prompts were recorded, or of a server without the capability, has
   // no `prompts` key; diffing it as empty means a live server's prompts show up as added, which
   // is the honest answer (regenerating the snapshot resolves it).
   const beforePrompts = before.prompts ?? {};
   const afterPrompts = after.prompts ?? {};
-  const beforePromptNames = Object.keys(beforePrompts).sort();
-  const afterPromptNames = Object.keys(afterPrompts).sort();
-  const promptsAdded = afterPromptNames.filter((n) => !(n in beforePrompts));
-  const promptsRemoved = beforePromptNames.filter((n) => !(n in afterPrompts));
-  const promptsChanged = afterPromptNames.filter(
-    (n) => n in beforePrompts && !deepEqual(beforePrompts[n], afterPrompts[n]),
-  );
+  const prompts = diffKeys(beforePrompts, afterPrompts);
+  for (const name of prompts.added) push("promptAdded", name, "added prompt", "additive");
+  for (const name of prompts.removed) push("promptRemoved", name, "removed prompt", "breaking");
+  for (const name of prompts.common) {
+    const b = beforePrompts[name];
+    const a = afterPrompts[name];
+    if (!b || !a || deepEqual(b, a)) continue;
+    const details = promptArgumentChanges(b.arguments, a.arguments);
+    push("promptArguments", name, "prompt arguments changed", worstOf(details), details);
+  }
 
-  const identical =
-    added.length === 0 &&
-    removed.length === 0 &&
-    inputChanged.length === 0 &&
-    outputChanged.length === 0 &&
-    annotationsChanged.length === 0 &&
-    promptsAdded.length === 0 &&
-    promptsRemoved.length === 0 &&
-    promptsChanged.length === 0;
+  const subjects = (...kinds: CheckChangeKind[]): string[] =>
+    changes
+      .filter((c) => kinds.includes(c.kind))
+      .map((c) => c.subject)
+      .sort();
 
   return {
-    added,
-    removed,
-    inputChanged,
-    outputAppeared,
-    outputDisappeared,
-    outputChanged,
-    annotationsChanged,
-    safetyWeakened,
-    promptsAdded,
-    promptsRemoved,
-    promptsChanged,
-    identical,
+    added: subjects("toolAdded"),
+    removed: subjects("toolRemoved"),
+    inputChanged: subjects("inputSchema"),
+    outputAppeared: subjects("outputSchemaAppeared"),
+    outputDisappeared: subjects("outputSchemaDisappeared"),
+    outputChanged: subjects("outputSchemaAppeared", "outputSchemaDisappeared", "outputSchema"),
+    annotationsChanged: subjects("annotations"),
+    safetyWeakened: changes
+      .filter((c) => c.kind === "annotations" && c.severity === "dangerous")
+      .map((c) => c.subject),
+    promptsAdded: subjects("promptAdded"),
+    promptsRemoved: subjects("promptRemoved"),
+    promptsChanged: subjects("promptArguments"),
+    changes: [...changes].sort(
+      (a, b) =>
+        bySeverity(a, b) || a.subject.localeCompare(b.subject) || a.kind.localeCompare(b.kind),
+    ),
+    severity: worstOf(changes),
+    identical: changes.length === 0,
   };
 }
 
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (typeof a !== typeof b) return false;
-  if (a === null || b === null || a === undefined || b === undefined) return a === b;
-  if (Array.isArray(a) || Array.isArray(b)) {
-    if (!Array.isArray(a) || !Array.isArray(b)) return false;
-    if (a.length !== b.length) return false;
-    return a.every((v, i) => deepEqual(v, b[i]));
-  }
-  if (typeof a === "object" && typeof b === "object") {
-    const ao = a as Record<string, unknown>;
-    const bo = b as Record<string, unknown>;
-    const ak = Object.keys(ao).sort();
-    const bk = Object.keys(bo).sort();
-    if (ak.length !== bk.length) return false;
-    return ak.every((k, i) => k === bk[i] && deepEqual(ao[k], bo[k]));
-  }
-  return false;
+/** One underlying difference behind a `CheckChange`; `path` is prefixed when present. */
+interface Detail {
+  severity: Severity;
+  message: string;
+  path?: string;
 }
+
+/** Worst first; when the change as a whole is not additive, the additive lines say so. */
+function formatDetails(details: Detail[], severity: Severity): string[] {
+  return [...details].sort(bySeverity).map((d) => {
+    const text =
+      d.path === undefined ? d.message : `${d.path === "" ? "(root)" : d.path}: ${d.message}`;
+    return severity !== "additive" && d.severity === "additive" ? `${text} (additive)` : text;
+  });
+}
+
+/**
+ * The annotations that promise something about a tool's behaviour, and the value that makes the
+ * promise. Going from that value to anything else withdraws it.
+ */
+const SAFETY_HINTS: ReadonlyArray<{ hint: string; safe: boolean }> = [
+  { hint: "readOnlyHint", safe: true },
+  { hint: "destructiveHint", safe: false },
+  { hint: "idempotentHint", safe: true },
+  { hint: "openWorldHint", safe: false },
+];
+
+function weakenedHints(
+  before: ToolAnnotationsSnapshot | undefined,
+  after: ToolAnnotationsSnapshot | undefined,
+): Detail[] {
+  return SAFETY_HINTS.filter(
+    ({ hint, safe }) => before?.[hint] === safe && after?.[hint] !== safe,
+  ).map(({ hint, safe }) => ({ severity: "dangerous", message: `${hint} is no longer ${safe}` }));
+}
+
+/** Prompt arguments are passed by name, so only the name set and the required flags matter. */
+function promptArgumentChanges(
+  before: PromptArgumentSnapshot[],
+  after: PromptArgumentSnapshot[],
+): Detail[] {
+  const b = Object.fromEntries(before.map((arg) => [arg.name, arg.required === true]));
+  const a = Object.fromEntries(after.map((arg) => [arg.name, arg.required === true]));
+  const { added, removed, common } = diffKeys(b, a);
+  const details: Detail[] = [];
+  for (const name of added) {
+    details.push({
+      path: name,
+      severity: a[name] ? "breaking" : "additive",
+      message: a[name] ? "new required argument" : "new optional argument",
+    });
+  }
+  for (const name of common) {
+    if (a[name] === b[name]) continue;
+    details.push({
+      path: name,
+      severity: a[name] ? "breaking" : "additive",
+      message: a[name] ? "is now required" : "is no longer required",
+    });
+  }
+  for (const name of removed)
+    details.push({ path: name, severity: "breaking", message: "argument removed" });
+  // Same names and flags in a different order: nothing a caller can observe.
+  if (details.length === 0)
+    details.push({ severity: "additive", message: "argument order changed" });
+  return details;
+}
+
+/** How many `reasons` lines a single change is allowed before the rest are summarized. */
+const MAX_REASON_LINES = 6;
+
+/** Report sections, worst first. */
+const SEVERITIES: readonly Severity[] = ["breaking", "dangerous", "additive"];
 
 export function formatReport(report: CheckReport, against: string): string {
   if (report.identical) {
     return `mcp-tada check: no differences from ${against}\n`;
   }
-  const lines: string[] = [`mcp-tada check: differences from ${against}`];
-  if (report.added.length > 0) lines.push(`  added tools: ${report.added.join(", ")}`);
-  if (report.removed.length > 0) lines.push(`  removed tools: ${report.removed.join(", ")}`);
-  if (report.inputChanged.length > 0) {
-    lines.push(`  inputSchema changed: ${report.inputChanged.join(", ")}`);
-  }
-  if (report.outputAppeared.length > 0) {
-    lines.push(`  outputSchema appeared: ${report.outputAppeared.join(", ")}`);
-  }
-  if (report.outputDisappeared.length > 0) {
-    lines.push(`  outputSchema disappeared: ${report.outputDisappeared.join(", ")}`);
-  }
-  if (report.outputChanged.length > 0) {
-    lines.push(`  outputSchema changed: ${report.outputChanged.join(", ")}`);
-  }
-  if (report.annotationsChanged.length > 0) {
-    lines.push(`  annotations changed: ${report.annotationsChanged.join(", ")}`);
-  }
-  if (report.safetyWeakened.length > 0) {
-    lines.push(`  no longer read-only or non-destructive: ${report.safetyWeakened.join(", ")}`);
-  }
-  if (report.promptsAdded.length > 0) {
-    lines.push(`  added prompts: ${report.promptsAdded.join(", ")}`);
-  }
-  if (report.promptsRemoved.length > 0) {
-    lines.push(`  removed prompts: ${report.promptsRemoved.join(", ")}`);
-  }
-  if (report.promptsChanged.length > 0) {
-    lines.push(`  prompt arguments changed: ${report.promptsChanged.join(", ")}`);
+  const groups = SEVERITIES.map((severity) => ({
+    severity,
+    changes: report.changes.filter((c) => c.severity === severity),
+  })).filter((g) => g.changes.length > 0);
+  const counts = groups.map((g) => `${g.changes.length} ${g.severity}`).join(", ");
+  const lines: string[] = [`mcp-tada check: differences from ${against} (${counts})`];
+  for (const group of groups) {
+    lines.push(`  ${group.severity}:`);
+    for (const change of group.changes) lines.push(...formatChange(change));
   }
   lines.push("");
   return lines.join("\n");
+}
+
+function formatChange(change: CheckChange): string[] {
+  const lines = [`    ${change.subject}: ${change.summary}`];
+  for (const reason of change.reasons.slice(0, MAX_REASON_LINES)) lines.push(`      ${reason}`);
+  const hidden = change.reasons.length - MAX_REASON_LINES;
+  if (hidden > 0) lines.push(`      ... and ${hidden} more difference${hidden === 1 ? "" : "s"}`);
+  return lines;
 }

--- a/packages/mcp-tada/src/cli/compat.ts
+++ b/packages/mcp-tada/src/cli/compat.ts
@@ -1,0 +1,391 @@
+// Classifying a JSON Schema difference as breaking or additive, from the point of view of code
+// written against the older schema.
+//
+// Direction decides which way compatibility runs. An `inputSchema` is written by the caller, so
+// it is contravariant: loosening it (fewer required properties, a wider `type`, a looser bound)
+// keeps existing calls valid, tightening it breaks them. An `outputSchema` is read by the
+// caller, so it is covariant: the rules invert. Everything unrecognized is reported as breaking,
+// so a schema keyword this does not model can only ever make `check` stricter, never quieter.
+//
+// Each keyword has one entry in `KEYWORDS`; that table is also the list of what is understood,
+// so supporting a new keyword is a single line.
+
+/** Which side of the call the schema describes: `"input"` is contravariant, `"output"` covariant. */
+export type SchemaDirection = "input" | "output";
+
+/**
+ * How much a difference can hurt code written against the older snapshot. `additive` cannot;
+ * `dangerous` keeps the contract but weakens a behavioural guarantee (a tool that stopped
+ * promising to be read-only); `breaking` means calls or reads can stop working.
+ */
+export type Severity = "additive" | "dangerous" | "breaking";
+
+const RANK: Record<Severity, number> = { additive: 0, dangerous: 1, breaking: 2 };
+
+/** True when `severity` is at least as bad as `threshold`. */
+export function atLeast(severity: Severity, threshold: Severity): boolean {
+  return RANK[severity] >= RANK[threshold];
+}
+
+/** The worst severity in `items`, `additive` when there are none. */
+export function worstOf(items: readonly { severity: Severity }[]): Severity {
+  let worst: Severity = "additive";
+  for (const item of items) if (RANK[item.severity] > RANK[worst]) worst = item.severity;
+  return worst;
+}
+
+/** Sort key: worst first. */
+export function bySeverity(a: { severity: Severity }, b: { severity: Severity }): number {
+  return RANK[b.severity] - RANK[a.severity];
+}
+
+export interface SchemaChange {
+  /** Where in the schema the change is, as a dotted path (`""` for the root, `.a[].b` inside). */
+  path: string;
+  severity: Severity;
+  /** One line, without the path: `type string -> number`, `property "b" is now required`. */
+  message: string;
+}
+
+/**
+ * Diff two JSON Schemas, classifying each difference for `direction`. An empty result means the
+ * schemas are equivalent apart from documentation keywords.
+ */
+export function compareSchemas(
+  before: unknown,
+  after: unknown,
+  direction: SchemaDirection,
+): SchemaChange[] {
+  const out: SchemaChange[] = [];
+  walk(before, after, new Scope(direction, out, ""));
+  return out;
+}
+
+/** Keywords that carry documentation rather than constraints; a change to one is never breaking. */
+const ANNOTATION_KEYWORDS = new Set([
+  "$comment",
+  "$id",
+  "$schema",
+  "default",
+  "deprecated",
+  "description",
+  "examples",
+  "title",
+]);
+
+/** One schema node being compared: where it is, and how to report what differs at it. */
+class Scope {
+  constructor(
+    private readonly direction: SchemaDirection,
+    private readonly out: SchemaChange[],
+    readonly path: string,
+  ) {}
+
+  /** Recurse into a sub-schema at `path`. */
+  walk(before: unknown, after: unknown, path: string): void {
+    walk(before, after, new Scope(this.direction, this.out, path));
+  }
+
+  /** A change that rejects values the old schema accepted: breaking for what we send. */
+  tightened(message: string, path = this.path): void {
+    this.constrained(true, message, path);
+  }
+
+  /** A change that admits values the old schema rejected: breaking for what we receive. */
+  loosened(message: string, path = this.path): void {
+    this.constrained(false, message, path);
+  }
+
+  /** Report a tightening or loosening; the direction decides which of those breaks. */
+  constrained(tighter: boolean, message: string, path = this.path): void {
+    const breaks = tighter ? this.direction === "input" : this.direction === "output";
+    this.emit(breaks ? "breaking" : "additive", message, path);
+  }
+
+  /** Breaking whichever way the schema is used, or not comparable at all. */
+  broken(message: string, path = this.path): void {
+    this.emit("breaking", message, path);
+  }
+
+  additive(message: string, path = this.path): void {
+    this.emit("additive", message, path);
+  }
+
+  private emit(severity: Severity, message: string, path: string): void {
+    this.out.push({ path, severity, message });
+  }
+}
+
+/** Compares one keyword's value on both sides; only called when the two differ. */
+type Handler = (before: unknown, after: unknown, keyword: string, cx: Scope) => void;
+
+/**
+ * The common shape: a constraint that appears tightens, one that disappears loosens, and
+ * `whenBoth` decides the rest.
+ */
+function presence(whenBoth: Handler): Handler {
+  return (before, after, keyword, cx) => {
+    if (before === undefined) cx.tightened(`${keyword} added (${show(after)})`);
+    else if (after === undefined) cx.loosened(`${keyword} removed`);
+    else whenBoth(before, after, keyword, cx);
+  };
+}
+
+/** Two concrete values that cannot be ordered against each other. */
+const incomparable: Handler = (before, after, keyword, cx) =>
+  cx.broken(`${keyword} ${show(before)} -> ${show(after)}`);
+
+/** `minimum: 5` allows less than `minimum: 1`, so for a lower bound the larger value is tighter. */
+const bound = (side: "lower" | "upper"): Handler =>
+  presence((before, after, keyword, cx) => {
+    if (typeof before !== "number" || typeof after !== "number") {
+      return incomparable(before, after, keyword, cx);
+    }
+    const tighter = side === "lower" ? after > before : after < before;
+    cx.constrained(tighter, `${keyword} ${before} -> ${after}`);
+  });
+
+/**
+ * A branch added to `anyOf` widens the schema and one added to `allOf` narrows it. `oneOf` is
+ * neither: a new branch that overlaps an old one turns a previously valid value into a
+ * two-match rejection, so its changes are breaking either way.
+ */
+const combinator = (addingWidens: boolean | "unknown"): Handler =>
+  presence((before, after, keyword, cx) => {
+    if (!Array.isArray(before) || !Array.isArray(after)) {
+      return cx.broken(`${keyword} changed`);
+    }
+    const { added, removed } = diffValues(before, after);
+    const report = (tighter: boolean, message: string): void =>
+      addingWidens === "unknown" ? cx.broken(message) : cx.constrained(tighter, message);
+    if (added.length > 0) {
+      report(addingWidens === false, `${keyword}: ${added.length} branch(es) added`);
+    }
+    if (removed.length > 0) {
+      report(addingWidens === true, `${keyword}: ${removed.length} branch(es) removed`);
+    }
+  });
+
+const definitions: Handler = (before, after, keyword, cx) => {
+  if (!isRecord(before) || !isRecord(after)) return cx.broken(`${keyword} changed`);
+  const { common, removed } = diffKeys(before, after);
+  for (const name of common) cx.walk(before[name], after[name], `${cx.path}#${name}`);
+  for (const name of removed) cx.broken("definition removed", `${cx.path}#${name}`);
+};
+
+const KEYWORDS: Record<string, Handler> = {
+  type(before, after, _keyword, cx) {
+    const b = typeSet(before);
+    const a = typeSet(after);
+    if (setEqual(b, a)) return;
+    const message = `type ${formatTypes(b)} -> ${formatTypes(a)}`;
+    // A missing `type` means "any type", so it is the widest set there is.
+    const bWidest = b.size === 0;
+    const aWidest = a.size === 0;
+    if (bWidest && !aWidest) cx.tightened(message);
+    else if (!bWidest && aWidest) cx.loosened(message);
+    else if (isSubset(b, a)) cx.loosened(message);
+    else if (isSubset(a, b)) cx.tightened(message);
+    else cx.broken(message);
+  },
+
+  required(before, after, _keyword, cx) {
+    const { added, removed } = diffValues(stringArray(before), stringArray(after));
+    for (const name of added) cx.tightened("is now required", child(cx.path, name));
+    for (const name of removed) cx.loosened("is no longer required", child(cx.path, name));
+  },
+
+  properties(before, after, _keyword, cx) {
+    const b = isRecord(before) ? before : {};
+    const a = isRecord(after) ? after : {};
+    const { added, removed, common } = diffKeys(b, a);
+    for (const name of common) cx.walk(b[name], a[name], child(cx.path, name));
+    // Gone from the schema in either direction: a caller that passed it no longer type-checks,
+    // and a caller that read it no longer gets it.
+    for (const name of removed) cx.broken("property removed", child(cx.path, name));
+    // Whether this is safe to ignore is decided by `required`, which is compared separately.
+    for (const name of added) cx.additive("property added", child(cx.path, name));
+  },
+
+  additionalProperties(before, after, _keyword, cx) {
+    if (isRecord(before) && isRecord(after)) return cx.walk(before, after, `${cx.path}[key]`);
+    // Absent means "allowed", so only an explicit `false` narrows, and `undefined` -> `true` is
+    // a server spelling out what it already meant.
+    const closed = after === false;
+    if (closed !== (before === false)) {
+      const message = closed
+        ? "no longer allows additional properties"
+        : "now allows additional properties";
+      return cx.constrained(closed, message);
+    }
+    // One side constrains the extra properties and the other does not.
+    const constrained = isRecord(after);
+    if (constrained || isRecord(before)) {
+      const message = constrained
+        ? "additional properties are now constrained"
+        : "additional properties are no longer constrained";
+      cx.constrained(constrained, message);
+    }
+  },
+
+  items: presence((before, after, _keyword, cx) => cx.walk(before, after, `${cx.path}[]`)),
+
+  prefixItems: presence((before, after, keyword, cx) => {
+    if (Array.isArray(before) && Array.isArray(after) && before.length === after.length) {
+      for (const [i, b] of before.entries()) cx.walk(b, after[i], `${cx.path}[${i}]`);
+    } else {
+      cx.broken(`${keyword} changed`);
+    }
+  }),
+
+  const: presence(incomparable),
+
+  enum: presence((before, after, keyword, cx) => {
+    if (!Array.isArray(before) || !Array.isArray(after)) {
+      return incomparable(before, after, keyword, cx);
+    }
+    const { added, removed } = diffValues(before, after);
+    if (removed.length > 0) cx.tightened(`enum no longer accepts ${formatValues(removed)}`);
+    if (added.length > 0) cx.loosened(`enum now includes ${formatValues(added)}`);
+    // Neither list populated means the values were only reordered, which changes nothing.
+  }),
+
+  anyOf: combinator(true),
+  oneOf: combinator("unknown"),
+  allOf: combinator(false),
+
+  minimum: bound("lower"),
+  exclusiveMinimum: bound("lower"),
+  minLength: bound("lower"),
+  minItems: bound("lower"),
+  minProperties: bound("lower"),
+  maximum: bound("upper"),
+  exclusiveMaximum: bound("upper"),
+  maxLength: bound("upper"),
+  maxItems: bound("upper"),
+  maxProperties: bound("upper"),
+
+  // Two concrete patterns are not comparable without deciding regex containment.
+  pattern: presence(incomparable),
+  format: presence(incomparable),
+  multipleOf: presence(incomparable),
+
+  uniqueItems(before, after, _keyword, cx) {
+    // `undefined` and `false` both mean "duplicates allowed", so only a flip to `true` matters.
+    const unique = after === true;
+    if (unique === (before === true)) return;
+    cx.constrained(unique, unique ? "items must now be unique" : "items need no longer be unique");
+  },
+
+  $ref: (before, after, keyword, cx) =>
+    cx.broken(`${keyword} ${String(before)} -> ${String(after)}`),
+  $defs: definitions,
+  definitions,
+};
+
+/** `true` (or `{}`) accepts everything and `false` nothing; any other schema sits in between. */
+function width(schema: unknown): number {
+  if (schema === true || (isRecord(schema) && Object.keys(schema).length === 0)) return 2;
+  return schema === false ? 0 : 1;
+}
+
+function walk(before: unknown, after: unknown, cx: Scope): void {
+  if (deepEqual(before, after)) return;
+  // A boolean schema can only be compared whole, but its direction is still known.
+  if (typeof before === "boolean" || typeof after === "boolean") {
+    return cx.constrained(width(after) < width(before), `schema ${show(before)} -> ${show(after)}`);
+  }
+  if (!isRecord(before) || !isRecord(after)) return cx.broken("schema changed");
+  // Table order first so the report reads top-down; unknown keywords after.
+  const keys = new Set([...Object.keys(KEYWORDS), ...Object.keys(before), ...Object.keys(after)]);
+  for (const keyword of keys) {
+    if (ANNOTATION_KEYWORDS.has(keyword) || deepEqual(before[keyword], after[keyword])) continue;
+    const handler = Object.hasOwn(KEYWORDS, keyword) ? KEYWORDS[keyword] : undefined;
+    // Anything this module does not model is reported as breaking rather than silently accepted.
+    if (handler) handler(before[keyword], after[keyword], keyword, cx);
+    else cx.broken(`${keyword} changed`);
+  }
+}
+
+/** Keys added, removed, and shared between two records, each sorted. */
+export function diffKeys(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): { added: string[]; removed: string[]; common: string[] } {
+  const b = Object.keys(before).sort();
+  const a = Object.keys(after).sort();
+  return {
+    added: a.filter((k) => !(k in before)),
+    removed: b.filter((k) => !(k in after)),
+    common: a.filter((k) => k in before),
+  };
+}
+
+/** Elements of `after` not in `before` and vice versa, by structural equality; order is ignored. */
+export function diffValues<T>(before: T[], after: T[]): { added: T[]; removed: T[] } {
+  return {
+    added: after.filter((v) => !before.some((o) => deepEqual(v, o))),
+    removed: before.filter((v) => !after.some((o) => deepEqual(v, o))),
+  };
+}
+
+function child(path: string, name: string): string {
+  return `${path}.${name}`;
+}
+
+/** A value for an error message, cut short when it is a large schema fragment. */
+function show(value: unknown): string {
+  const json = JSON.stringify(value) ?? String(value);
+  return json.length > 40 ? `${json.slice(0, 37)}...` : json;
+}
+
+function typeSet(type: unknown): Set<string> {
+  return new Set(typeof type === "string" ? [type] : stringArray(type));
+}
+
+function formatTypes(types: Set<string>): string {
+  return types.size === 0 ? "any" : [...types].sort().join("|");
+}
+
+function formatValues(values: unknown[]): string {
+  const shown = values.slice(0, 3).map((v) => JSON.stringify(v));
+  return values.length > 3 ? `${shown.join(", ")}, ...` : shown.join(", ");
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+function setEqual(a: Set<string>, b: Set<string>): boolean {
+  return a.size === b.size && isSubset(a, b);
+}
+
+function isSubset(a: Set<string>, b: Set<string>): boolean {
+  for (const v of a) if (!b.has(v)) return false;
+  return true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Structural equality over JSON data: key order does not matter, array order does. */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null || a === undefined || b === undefined) return a === b;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ao = a as Record<string, unknown>;
+    const bo = b as Record<string, unknown>;
+    const ak = Object.keys(ao).sort();
+    const bk = Object.keys(bo).sort();
+    if (ak.length !== bk.length) return false;
+    return ak.every((k, i) => k === bk[i] && deepEqual(ao[k], bo[k]));
+  }
+  return false;
+}

--- a/packages/mcp-tada/src/cli/doctor.ts
+++ b/packages/mcp-tada/src/cli/doctor.ts
@@ -213,14 +213,17 @@ export async function doctor(opts: DoctorOptions = {}): Promise<DoctorResult> {
         const count = Object.keys(live.tools).length;
         if (snapshot === undefined) {
           push("ok", alias, `reachable: ${name}, ${count} tools`);
-        } else if (diffIntrospection(snapshot, live).identical) {
-          push("ok", alias, `reachable: ${name}, ${count} tools, snapshot up to date`);
         } else {
-          push(
-            "warn",
-            alias,
-            `reachable: ${name}, ${count} tools, snapshot differs (run \`mcp-tada check ${alias}\`)`,
-          );
+          const report = diffIntrospection(snapshot, live);
+          if (report.identical) {
+            push("ok", alias, `reachable: ${name}, ${count} tools, snapshot up to date`);
+          } else {
+            push(
+              "warn",
+              alias,
+              `reachable: ${name}, ${count} tools, snapshot differs (${report.severity}; run \`mcp-tada check ${alias}\`)`,
+            );
+          }
         }
       } catch (err) {
         push("fail", alias, `unreachable: ${(err as Error).message}`);

--- a/packages/mcp-tada/src/cli/index.ts
+++ b/packages/mcp-tada/src/cli/index.ts
@@ -34,10 +34,14 @@ export {
   check,
   diffIntrospection,
   formatReport,
+  type CheckChange,
+  type CheckChangeKind,
   type CheckOptions,
   type CheckReport,
   type CheckRunResult,
+  type Severity,
 } from "./check.js";
+export { compareSchemas, type SchemaChange, type SchemaDirection } from "./compat.js";
 export {
   DEFAULT_CONFIG_PATH,
   candidateSources,

--- a/packages/mcp-tada/src/cli/main.ts
+++ b/packages/mcp-tada/src/cli/main.ts
@@ -14,7 +14,8 @@ import {
   type ServerTarget,
 } from "./connect.js";
 import { introspect } from "./introspect.js";
-import { check } from "./check.js";
+import { check, type Severity } from "./check.js";
+import { atLeast } from "./compat.js";
 import { init } from "./init.js";
 import { doctor } from "./doctor.js";
 
@@ -24,7 +25,7 @@ Usage:
   mcp-tada init [--from <path>] [--out-dir <dir>] [--force]
   mcp-tada doctor [--config <path>] [--offline] [--timeout <ms>]
   mcp-tada introspect [target flags] [--out <path>] [--name <TypeName>] [--json] [--verbose]
-  mcp-tada check [target flags] --against <path>
+  mcp-tada check [target flags] --against <path> [--fail-on <level>]
   mcp-tada --help
   mcp-tada --version
 
@@ -45,10 +46,24 @@ Target flags (one of):
   --timeout <ms>                 connect and tools/list timeout, default 30000 (overrides a
                                   server's "timeoutMs" in --config)
 
+check flags:
+  --fail-on <level>              the least severe difference that exits 1: "any" (default),
+                                  "dangerous" (a tool withdrew a safety hint, or worse), or
+                                  "breaking" (a removed tool, a newly required argument, a
+                                  narrowed input or widened output schema). Milder differences
+                                  are still reported.
+
 With --config and more than one server selected, --out is rejected: it would make every server
 overwrite the same file. Use each server's "output" in the config, or select one alias.
 
 See docs/cli.md for the config file format and more examples.`;
+
+/** `--fail-on` values, mapped to the severity threshold they set. */
+const FAIL_ON: Record<string, Severity> = {
+  any: "additive",
+  dangerous: "dangerous",
+  breaking: "breaking",
+};
 
 interface TargetFlagValues {
   command?: string;
@@ -220,6 +235,7 @@ async function runIntrospect(argv: string[]): Promise<number> {
 
 export interface RunCheckArgs extends TargetFlagValues {
   against?: string;
+  "fail-on"?: string;
   help?: boolean;
   aliasFilter?: string | undefined;
 }
@@ -239,52 +255,70 @@ export async function runCheckWith(values: RunCheckArgs): Promise<number> {
     return 1;
   }
 
+  const failOn = values["fail-on"] ?? "any";
+  const threshold = FAIL_ON[failOn];
+  if (!threshold) {
+    console.error(
+      `mcp-tada check: unknown --fail-on level ${JSON.stringify(failOn)}, expected one of ${Object.keys(FAIL_ON).join(", ")}`,
+    );
+    return 1;
+  }
+
+  // One (target, snapshot) pair per server to check, from the flags or from the config.
+  const runs: Array<{ target: ServerTarget; against: string }> = [];
+  let failed = false;
   const explicitTarget = targetFromFlags(values);
   if (explicitTarget) {
     if (!values.against) {
       console.error("mcp-tada check: --against <path> is required");
       return 1;
     }
-    const { report, text } = await check({ target: explicitTarget, against: values.against });
-    process.stdout.write(text);
-    return report.identical ? 0 : 1;
+    runs.push({ target: explicitTarget, against: values.against });
+  } else {
+    const configPath =
+      values.config ?? (existsSync("mcp-tada.config.json") ? "mcp-tada.config.json" : undefined);
+    if (!configPath) {
+      console.error(
+        "mcp-tada check: no target specified. Pass --command/--stdio/--url, or --config.",
+      );
+      return 1;
+    }
+    const config = loadConfig(configPath);
+    const aliasFilter = values.aliasFilter;
+    const aliases = aliasFilter ? [aliasFilter] : Object.keys(config.servers);
+    if (aliasFilter && !config.servers[aliasFilter]) {
+      console.error(`mcp-tada check: no server "${aliasFilter}" in ${configPath}`);
+      return 1;
+    }
+    for (const alias of aliases) {
+      const entry = config.servers[alias];
+      if (!entry) continue;
+      const against = values.against ?? entry.output;
+      if (!against) {
+        console.error(
+          `mcp-tada check: ${alias} has no "output" in ${configPath} and no --against was given`,
+        );
+        failed = true;
+        continue;
+      }
+      runs.push({ target: configEntryToTarget(entry, timeoutMs), against });
+    }
   }
 
-  const configPath =
-    values.config ?? (existsSync("mcp-tada.config.json") ? "mcp-tada.config.json" : undefined);
-  if (!configPath) {
-    console.error(
-      "mcp-tada check: no target specified. Pass --command/--stdio/--url, or --config.",
-    );
-    return 1;
-  }
-  const config = loadConfig(configPath);
-  const aliasFilter = values.aliasFilter;
-  const aliases = aliasFilter ? [aliasFilter] : Object.keys(config.servers);
-  if (aliasFilter && !config.servers[aliasFilter]) {
-    console.error(`mcp-tada check: no server "${aliasFilter}" in ${configPath}`);
-    return 1;
-  }
-  let anyDiff = false;
-  for (const alias of aliases) {
-    const entry = config.servers[alias];
-    if (!entry) continue;
-    const against = values.against ?? entry.output;
-    if (!against) {
-      console.error(
-        `mcp-tada check: ${alias} has no "output" in ${configPath} and no --against was given`,
-      );
-      anyDiff = true;
-      continue;
-    }
-    const { report, text } = await check({
-      target: configEntryToTarget(entry, timeoutMs),
-      against,
-    });
+  let drifted = false;
+  for (const run of runs) {
+    const { report, text } = await check(run);
     process.stdout.write(text);
-    if (!report.identical) anyDiff = true;
+    drifted ||= !report.identical;
+    failed ||= !report.identical && atLeast(report.severity, threshold);
   }
-  return anyDiff ? 1 : 0;
+  // A green run with a non-empty report should still say why it is green.
+  if (drifted && !failed) {
+    console.error(
+      `mcp-tada check: nothing ${failOn} or worse, passing because of --fail-on ${failOn}`,
+    );
+  }
+  return failed ? 1 : 0;
 }
 
 async function runCheck(argv: string[]): Promise<number> {
@@ -293,6 +327,7 @@ async function runCheck(argv: string[]): Promise<number> {
     options: {
       ...TARGET_OPTIONS,
       against: { type: "string" },
+      "fail-on": { type: "string" },
       help: { type: "boolean" },
     },
     allowPositionals: true,

--- a/packages/mcp-tada/test/cli.test.ts
+++ b/packages/mcp-tada/test/cli.test.ts
@@ -6,7 +6,7 @@ import type { ServerTarget } from "../src/cli/connect.js";
 import { introspect } from "../src/cli/introspect.js";
 import { check } from "../src/cli/check.js";
 import { parseDtsSnapshot, parseSnapshotText, detectFormat } from "../src/cli/snapshot.js";
-import { runIntrospectWith } from "../src/cli/main.js";
+import { runCheckWith, runIntrospectWith } from "../src/cli/main.js";
 
 const EVERYTHING_SERVER = "node_modules/@modelcontextprotocol/server-everything/dist/index.js";
 
@@ -156,7 +156,7 @@ describe("check", () => {
     expect(report.promptsAdded).toEqual(["simple-prompt"]);
     expect(report.promptsRemoved).toEqual(["retired-prompt"]);
     expect(report.promptsChanged).toEqual(["args-prompt"]);
-    expect(text).toContain("prompt arguments changed: args-prompt");
+    expect(text).toContain("args-prompt: prompt arguments changed");
   }, 30_000);
 
   it("treats a snapshot taken before prompts were recorded as having none", async () => {
@@ -190,8 +190,48 @@ describe("check", () => {
     expect(report.identical).toBe(false);
     expect(report.annotationsChanged).toEqual(["echo", "get-env", "gzip-file-as-resource"]);
     expect(report.safetyWeakened).toEqual(["gzip-file-as-resource"]);
-    expect(text).toContain("annotations changed: echo, get-env, gzip-file-as-resource");
-    expect(text).toContain("no longer read-only or non-destructive: gzip-file-as-resource");
+    expect(text).toContain("echo: annotations changed");
+    expect(text).toContain("get-env: annotations changed");
+    expect(text).toContain("gzip-file-as-resource: lost a safety guarantee");
+    expect(report.severity).toBe("dangerous");
+  }, 30_000);
+
+  it("exits 0 on additive drift with --fail-on breaking, and 1 without it", async () => {
+    const out = tmpFile("introspection.json");
+    const result = await introspect({ target, out, json: true });
+    const data = JSON.parse(result.text) as { tools: Record<string, unknown> };
+    // A tool the live server has and the snapshot does not: purely additive.
+    delete data.tools["echo"];
+    writeFileSync(out, JSON.stringify(data, null, 2));
+
+    const flags = { command: `node ${EVERYTHING_SERVER}`, against: out };
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(await runCheckWith({ ...flags, "fail-on": "breaking" })).toBe(0);
+      expect(await runCheckWith({ ...flags, "fail-on": "dangerous" })).toBe(0);
+      expect(errorSpy.mock.calls.flat().join("\n")).toContain(
+        "passing because of --fail-on breaking",
+      );
+      expect(await runCheckWith(flags)).toBe(1);
+      expect(await runCheckWith({ ...flags, "fail-on": "sometimes" })).toBe(1);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  }, 60_000);
+
+  it("exits 1 on breaking drift even with --fail-on breaking", async () => {
+    const out = tmpFile("introspection.json");
+    const result = await introspect({ target, out, json: true });
+    const data = JSON.parse(result.text) as { tools: Record<string, unknown> };
+    data.tools["a-tool-that-no-longer-exists"] = { inputSchema: { type: "object" } };
+    writeFileSync(out, JSON.stringify(data, null, 2));
+
+    const code = await runCheckWith({
+      command: `node ${EVERYTHING_SERVER}`,
+      against: out,
+      "fail-on": "breaking",
+    });
+    expect(code).toBe(1);
   }, 30_000);
 });
 

--- a/packages/mcp-tada/test/compat.test.ts
+++ b/packages/mcp-tada/test/compat.test.ts
@@ -1,0 +1,341 @@
+// The severity classification `mcp-tada check --fail-on` decides on. All of it is pure data, so
+// these run without a server.
+import { describe, expect, it } from "vitest";
+import { compareSchemas, worstOf } from "../src/cli/compat.js";
+import { diffIntrospection, formatReport } from "../src/cli/check.js";
+import type { IntrospectionData } from "../src/cli/snapshot.js";
+
+/** The worst `compareSchemas` verdict for a pair that must differ. */
+function verdict(before: unknown, after: unknown, direction: "input" | "output"): string {
+  const changes = compareSchemas(before, after, direction);
+  expect(changes.length, JSON.stringify(changes)).toBeGreaterThan(0);
+  return worstOf(changes);
+}
+
+const OBJ = (properties: Record<string, unknown>, required: string[] = []) => ({
+  type: "object",
+  properties,
+  required,
+});
+
+describe("compareSchemas: input schemas are contravariant", () => {
+  const base = OBJ({ a: { type: "string" }, b: { type: "number" } }, ["a"]);
+
+  it("reports nothing when only documentation changed", () => {
+    const after = OBJ({ a: { type: "string", description: "the a" }, b: { type: "number" } }, [
+      "a",
+    ]);
+    expect(compareSchemas(base, after, "input")).toEqual([]);
+  });
+
+  it("treats a newly required property as breaking", () => {
+    const changes = compareSchemas(base, OBJ(base.properties, ["a", "b"]), "input");
+    expect(changes).toEqual([{ path: ".b", severity: "breaking", message: "is now required" }]);
+  });
+
+  it("treats a relaxed requirement as additive", () => {
+    expect(verdict(base, OBJ(base.properties, []), "input")).toBe("additive");
+  });
+
+  it("treats a new optional property as additive, and a removed one as breaking", () => {
+    const withC = OBJ({ ...base.properties, c: { type: "boolean" } }, ["a"]);
+    expect(verdict(base, withC, "input")).toBe("additive");
+    expect(verdict(base, OBJ({ a: { type: "string" } }, ["a"]), "input")).toBe("breaking");
+  });
+
+  it("treats a narrowed type as breaking and a widened one as additive", () => {
+    expect(
+      verdict(base, OBJ({ ...base.properties, a: { type: ["string", "null"] } }, ["a"]), "input"),
+    ).toBe("additive");
+    expect(verdict(OBJ({ a: {} }), OBJ({ a: { type: "string" } }), "input")).toBe("breaking");
+  });
+
+  it("treats a shrunk enum as breaking and a grown one as additive", () => {
+    const before = OBJ({ mode: { enum: ["fast", "slow"] } });
+    expect(verdict(before, OBJ({ mode: { enum: ["fast"] } }), "input")).toBe("breaking");
+    expect(verdict(before, OBJ({ mode: { enum: ["fast", "slow", "auto"] } }), "input")).toBe(
+      "additive",
+    );
+    // Reordering the same values constrains nothing differently.
+    expect(compareSchemas(before, OBJ({ mode: { enum: ["slow", "fast"] } }), "input")).toEqual([]);
+  });
+
+  it("treats a tightened bound as breaking and a loosened one as additive", () => {
+    const before = OBJ({ n: { type: "number", minimum: 0, maximum: 10 } });
+    expect(verdict(before, OBJ({ n: { type: "number", minimum: 1, maximum: 10 } }), "input")).toBe(
+      "breaking",
+    );
+    expect(verdict(before, OBJ({ n: { type: "number", minimum: 0, maximum: 20 } }), "input")).toBe(
+      "additive",
+    );
+    expect(verdict(before, OBJ({ n: { type: "number", minimum: 0 } }), "input")).toBe("additive");
+    expect(
+      verdict(
+        OBJ({ s: { type: "string" } }),
+        OBJ({ s: { type: "string", pattern: "^a" } }),
+        "input",
+      ),
+    ).toBe("breaking");
+  });
+
+  it("follows nested objects and arrays", () => {
+    const before = OBJ({ files: { type: "array", items: OBJ({ path: { type: "string" } }, []) } });
+    const after = OBJ({
+      files: { type: "array", items: OBJ({ path: { type: "string" } }, ["path"]) },
+    });
+    expect(compareSchemas(before, after, "input")).toEqual([
+      { path: ".files[].path", severity: "breaking", message: "is now required" },
+    ]);
+  });
+
+  it("treats closing an open object as breaking, and opening a closed one as additive", () => {
+    const open = { ...OBJ({ a: { type: "string" } }), additionalProperties: true };
+    const closed = { ...OBJ({ a: { type: "string" } }), additionalProperties: false };
+    expect(verdict(open, closed, "input")).toBe("breaking");
+    expect(verdict(closed, open, "input")).toBe("additive");
+  });
+
+  it("ignores a server spelling out a default it already had", () => {
+    const before = OBJ({ a: { type: "string" } });
+    const after = {
+      ...OBJ({ a: { type: "string" } }),
+      additionalProperties: true,
+      uniqueItems: false,
+    };
+    expect(compareSchemas(before, after, "input")).toEqual([]);
+    expect(compareSchemas(before, after, "output")).toEqual([]);
+  });
+
+  it("reports an unmodelled keyword as breaking rather than ignoring it", () => {
+    expect(verdict(OBJ({}), { ...OBJ({}), unevaluatedProperties: false }, "input")).toBe(
+      "breaking",
+    );
+    expect(verdict({ $ref: "#/$defs/a" }, { $ref: "#/$defs/b" }, "input")).toBe("breaking");
+    // Whichever direction: not comparable is never waved through.
+    expect(verdict(OBJ({}), { ...OBJ({}), unevaluatedProperties: false }, "output")).toBe(
+      "breaking",
+    );
+  });
+
+  it("classifies combinators by which way a branch moves the schema", () => {
+    const base = { anyOf: [{ type: "string" }, { type: "number" }] };
+    expect(verdict(base, { anyOf: [{ type: "string" }] }, "input")).toBe("breaking");
+    expect(verdict(base, { anyOf: [...base.anyOf, { type: "null" }] }, "input")).toBe("additive");
+    const all = { allOf: [{ minLength: 1 }] };
+    expect(verdict(all, { allOf: [{ minLength: 1 }, { maxLength: 9 }] }, "input")).toBe("breaking");
+    // A new `oneOf` branch that overlaps an old one rejects values that used to match once.
+    const one = { oneOf: [{ type: "string" }] };
+    expect(verdict(one, { oneOf: [{ type: "string" }, { enum: ["x"] }] }, "input")).toBe(
+      "breaking",
+    );
+    expect(verdict(one, { oneOf: [{ type: "string" }, { enum: ["x"] }] }, "output")).toBe(
+      "breaking",
+    );
+  });
+
+  it("keeps direction for boolean sub-schemas and prefixItems", () => {
+    const anyItems = { type: "array", items: true };
+    const strItems = { type: "array", items: { type: "string" } };
+    expect(verdict(anyItems, strItems, "input")).toBe("breaking");
+    expect(verdict(anyItems, strItems, "output")).toBe("additive");
+    expect(verdict(strItems, { type: "array", items: false }, "output")).toBe("additive");
+    const tuple = { type: "array", prefixItems: [{ type: "string" }] };
+    expect(verdict({ type: "array" }, tuple, "input")).toBe("breaking");
+    expect(verdict({ type: "array" }, tuple, "output")).toBe("additive");
+    expect(verdict(tuple, { type: "array", prefixItems: [{ type: "number" }] }, "output")).toBe(
+      "breaking",
+    );
+  });
+
+  it("walks items, additionalProperties schemas and definitions", () => {
+    expect(
+      compareSchemas(
+        { type: "object", additionalProperties: { type: "string" } },
+        { type: "object", additionalProperties: { type: ["string", "null"] } },
+        "output",
+      ),
+    ).toEqual([{ path: "[key]", severity: "breaking", message: "type string -> null|string" }]);
+    expect(
+      compareSchemas(
+        { $defs: { a: { type: "string" } }, $ref: "#/$defs/a" },
+        { $defs: { a: { type: "string", minLength: 1 } }, $ref: "#/$defs/a" },
+        "input",
+      ),
+    ).toEqual([{ path: "#a", severity: "breaking", message: "minLength added (1)" }]);
+    expect(verdict({ type: "array" }, { type: "array", items: { type: "string" } }, "input")).toBe(
+      "breaking",
+    );
+  });
+});
+
+describe("compareSchemas: output schemas are covariant", () => {
+  const base = OBJ({ a: { type: "string" }, b: { type: "number" } }, ["a"]);
+
+  it("inverts the requirement rules", () => {
+    expect(verdict(base, OBJ(base.properties, ["a", "b"]), "output")).toBe("additive");
+    expect(verdict(base, OBJ(base.properties, []), "output")).toBe("breaking");
+  });
+
+  it("inverts the type and enum rules", () => {
+    expect(
+      verdict(base, OBJ({ ...base.properties, a: { type: ["string", "null"] } }, ["a"]), "output"),
+    ).toBe("breaking");
+    const before = OBJ({ mode: { enum: ["fast", "slow"] } });
+    expect(verdict(before, OBJ({ mode: { enum: ["fast"] } }), "output")).toBe("additive");
+    expect(verdict(before, OBJ({ mode: { enum: ["fast", "slow", "auto"] } }), "output")).toBe(
+      "breaking",
+    );
+  });
+
+  it("still treats a removed property as breaking", () => {
+    expect(verdict(base, OBJ({ a: { type: "string" } }, ["a"]), "output")).toBe("breaking");
+    expect(
+      verdict(base, OBJ({ ...base.properties, c: { type: "boolean" } }, ["a"]), "output"),
+    ).toBe("additive");
+  });
+});
+
+describe("diffIntrospection classification", () => {
+  const snapshot: IntrospectionData = {
+    tools: {
+      keep: { inputSchema: OBJ({ a: { type: "string" } }, ["a"]) },
+      tighten: { inputSchema: OBJ({ a: { type: "string" }, b: { type: "number" } }, ["a"]) },
+      loosen: { inputSchema: OBJ({ a: { type: "string" } }, ["a"]) },
+      gone: { inputSchema: OBJ({}) },
+      safe: { inputSchema: OBJ({}), annotations: { readOnlyHint: true } },
+      titled: { inputSchema: OBJ({}), annotations: { title: "Before", readOnlyHint: true } },
+      structured: { inputSchema: OBJ({}), outputSchema: OBJ({ x: { type: "string" } }, ["x"]) },
+    },
+    prompts: {
+      stable: { arguments: [{ name: "city", required: true }] },
+      widened: { arguments: [{ name: "city", required: true }] },
+      narrowed: { arguments: [{ name: "city", required: false }] },
+      retired: { arguments: [] },
+    },
+  };
+
+  const live: IntrospectionData = {
+    tools: {
+      keep: { inputSchema: OBJ({ a: { type: "string" } }, ["a"]) },
+      tighten: { inputSchema: OBJ({ a: { type: "string" }, b: { type: "number" } }, ["a", "b"]) },
+      loosen: { inputSchema: OBJ({ a: { type: "string" }, c: { type: "string" } }, []) },
+      fresh: { inputSchema: OBJ({}) },
+      safe: { inputSchema: OBJ({}), annotations: { readOnlyHint: false } },
+      titled: { inputSchema: OBJ({}), annotations: { title: "After", readOnlyHint: true } },
+      structured: {
+        inputSchema: OBJ({}),
+        outputSchema: OBJ({ x: { type: "string" }, y: { type: "string" } }, ["x"]),
+      },
+    },
+    prompts: {
+      stable: { arguments: [{ name: "city", required: true }] },
+      widened: { arguments: [{ name: "city", required: false }] },
+      narrowed: { arguments: [{ name: "city", required: true }] },
+      added: { arguments: [] },
+    },
+  };
+
+  const report = diffIntrospection(snapshot, live);
+
+  function kindOf(subject: string) {
+    return report.changes.find((c) => c.subject === subject);
+  }
+
+  it("flags the report as breaking and keeps the per-category lists", () => {
+    expect(report.identical).toBe(false);
+    expect(report.severity).toBe("breaking");
+    expect(report.added).toEqual(["fresh"]);
+    expect(report.removed).toEqual(["gone"]);
+    expect(report.inputChanged).toEqual(["loosen", "tighten"]);
+    expect(report.safetyWeakened).toEqual(["safe"]);
+    expect(report.annotationsChanged).toEqual(["safe", "titled"]);
+    expect(report.outputChanged).toEqual(["structured"]);
+    expect(report.promptsChanged).toEqual(["narrowed", "widened"]);
+  });
+
+  it("splits tool changes by whether they can break a caller", () => {
+    expect(kindOf("fresh")).toMatchObject({ kind: "toolAdded", severity: "additive" });
+    expect(kindOf("gone")).toMatchObject({ kind: "toolRemoved", severity: "breaking" });
+    expect(kindOf("tighten")).toMatchObject({
+      kind: "inputSchema",
+      severity: "breaking",
+      reasons: [".b: is now required"],
+    });
+    expect(kindOf("loosen")).toMatchObject({ kind: "inputSchema", severity: "additive" });
+    expect(kindOf("structured")).toMatchObject({ kind: "outputSchema", severity: "additive" });
+  });
+
+  it("rates a lost safety hint dangerous, not breaking, and other annotation drift additive", () => {
+    expect(kindOf("safe")).toMatchObject({
+      kind: "annotations",
+      severity: "dangerous",
+      summary: "lost a safety guarantee",
+      reasons: ["readOnlyHint is no longer true"],
+    });
+    expect(kindOf("titled")).toMatchObject({ kind: "annotations", severity: "additive" });
+    const hints = diffIntrospection(
+      {
+        tools: {
+          t: {
+            inputSchema: OBJ({}),
+            annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false },
+          },
+        },
+      },
+      { tools: { t: { inputSchema: OBJ({}), annotations: {} } } },
+    );
+    expect(hints.severity).toBe("dangerous");
+    expect(hints.changes[0]?.reasons).toEqual([
+      "destructiveHint is no longer false",
+      "idempotentHint is no longer true",
+      "openWorldHint is no longer false",
+    ]);
+  });
+
+  it("splits prompt changes by whether a caller's arguments still fit", () => {
+    expect(kindOf("added")).toMatchObject({ kind: "promptAdded", severity: "additive" });
+    expect(kindOf("retired")).toMatchObject({ kind: "promptRemoved", severity: "breaking" });
+    expect(kindOf("widened")).toMatchObject({
+      kind: "promptArguments",
+      severity: "additive",
+      reasons: ["city: is no longer required"],
+    });
+    expect(kindOf("narrowed")).toMatchObject({ kind: "promptArguments", severity: "breaking" });
+    expect(kindOf("stable")).toBeUndefined();
+  });
+
+  it("orders worst first and counts each severity in the header", () => {
+    const text = formatReport(report, "snap.d.ts");
+    expect(text).toContain("differences from snap.d.ts (4 breaking, 1 dangerous, 6 additive)");
+    expect(text.indexOf("  breaking:")).toBeLessThan(text.indexOf("  dangerous:"));
+    expect(text.indexOf("  dangerous:")).toBeLessThan(text.indexOf("  additive:"));
+    expect(text).toContain("    tighten: inputSchema changed");
+    expect(text).toContain("      .b: is now required");
+    expect(text).toContain("    safe: lost a safety guarantee");
+    const breakingSection = text.slice(text.indexOf("  breaking:"), text.indexOf("  dangerous:"));
+    expect(breakingSection).not.toContain("fresh: added tool");
+    expect(breakingSection).not.toContain("safe:");
+  });
+
+  it("reports a documentation-only schema edit as an additive change", () => {
+    const before: IntrospectionData = { tools: { a: { inputSchema: OBJ({}) } } };
+    const after: IntrospectionData = {
+      tools: { a: { inputSchema: { ...OBJ({}), description: "now documented" } } },
+    };
+    const docs = diffIntrospection(before, after);
+    expect(docs.identical).toBe(false);
+    expect(docs.severity).toBe("additive");
+    expect(docs.changes[0]).toMatchObject({
+      severity: "additive",
+      reasons: ["documentation or ordering only"],
+    });
+  });
+
+  it("has no changes and no breaking flag for identical data", () => {
+    const same = diffIntrospection(snapshot, snapshot);
+    expect(same.identical).toBe(true);
+    expect(same.severity).toBe("additive");
+    expect(same.changes).toEqual([]);
+    expect(formatReport(same, "snap.d.ts")).toBe("mcp-tada check: no differences from snap.d.ts\n");
+  });
+});


### PR DESCRIPTION
## Summary

- \`mcp-tada check\` rates every difference as **additive**, **dangerous**, or **breaking** and groups the report by severity, worst first, with the reason under each entry.
- **Dangerous** is new: the contract still holds but a tool withdrew a promise (\`readOnlyHint\`/\`idempotentHint\` no longer true, \`destructiveHint\`/\`openWorldHint\` no longer false). Code trusting the hint still compiles, which is the point of calling it out separately from breaking.
- **Breaking** is judged by schema direction: tightening an \`inputSchema\` or loosening an \`outputSchema\` breaks callers, the reverse is additive. Anything the classifier cannot model (unknown keyword, changed \`$ref\`, incomparable \`pattern\`, \`oneOf\` edits) counts as breaking, so it never fails open.
- \`--fail-on <any|dangerous|breaking>\` picks the CI threshold (default \`any\`, the previous behaviour). Milder drift is still printed and the run says on stderr why it passed.
- \`doctor\` reports the worst severity when a snapshot differs.

## API

\`report.changes\` is the flat classified list (\`{ kind, subject, severity, summary, reasons }\`), \`report.severity\` the worst present, and \`compareSchemas(before, after, "input" | "output")\` is exported for diffing two schemas without a server. The existing per-category lists are unchanged.

## Design

\`compat.ts\` is a keyword-to-handler table. The set of understood keywords is derived from it, so supporting a new JSON Schema keyword is one entry, and a \`presence()\` factory covers the common "appeared tightens, disappeared loosens" shape. \`check.ts\` builds \`changes\` first and derives the legacy lists from it.
